### PR TITLE
pgr_depthFirstSearch GSoC-2020 Week [1] 

### DIFF
--- a/configuration.conf
+++ b/configuration.conf
@@ -37,10 +37,10 @@ chinese             | Y | Y | Y
 spanningTree        | Y | Y | Y
 mincut              | Y | Y | Y
 version             | Y | Y | Y
-topologicalSort     | Y | Y | Y 
+topologicalSort     | Y | Y | Y
 transitiveClosure   | Y | Y | Y
 breadthFirstSearch  | Y | Y | Y
-depthFirstSearch    | Y | Y | N
+depthFirstSearch    | Y | Y | Y
 #----------------------
 # SQL only directories
 #----------------------

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -165,6 +165,73 @@ Column           Type        Description
 .. result columns end
 
 
+Additional Examples
+-------------------------------------------------------------------------------
+
+The examples of this section are based on the :doc:`sampledata` network.
+
+.. TODO: CHANGE THIS
+   The examples include combinations ... in a directed and undirected graph.
+
+**Directed Graph**
+
+:Examples: For queries marked as ``directed`` with ``cost`` and ``reverse_cost`` columns
+
+The examples in this section use the following:
+
+* :ref:`fig1`
+
+.. TODO
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q3
+   :end-before: -- q4
+
+**Undirected Graph**
+
+:Examples: For queries marked as ``undirected`` with ``cost`` and ``reverse_cost`` columns
+
+The examples in this section use the following:
+
+* :ref:`fig2`
+
+.. TODO
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q4
+   :end-before: -- q5
+
+**Vertex Out Of Graph**
+
+:Example: For queries in which starting vertex is not present in the graph
+
+.. TODO:
+.. literalinclude:: doc-pgr_depthFirstSearch.queries
+   :start-after: --q5
+   :end-before: --q6
+
+Equivalences between signatures
+...............................................................................
+
+:Examples: For queries marked as ``directed`` with ``cost`` and ``reverse_cost`` columns
+
+The examples in this section use the following:
+
+* :ref:`fig1`
+
+.. TODO
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q6
+   :end-before: -- q7
+
+:Examples: For queries marked as ``undirected`` with ``cost`` and ``reverse_cost`` columns
+
+The examples in this section use the following:
+
+* :ref:`fig2`
+
+.. TODO
+.. literalinclude:: doc-pgr_dijkstra.queries
+   :start-after: -- q7
+   :end-before: -- q8
 
 
 See Also

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -204,8 +204,8 @@ The examples in this section use the following:
 :Example: For queries in which starting vertex is not present in the graph
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: --q5
-   :end-before: --q6
+   :start-after: -- q5
+   :end-before: -- q6
 
 Equivalences between signatures
 ...............................................................................

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -7,11 +7,12 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 
-pgr_depthFirstSearch
+pgr_depthFirstSearch - Experimental
 ===============================================================================
 
 ``pgr_depthFirstSearch`` — Returns the traversal order(s) using Depth
-First Search algorithm.
+  First Search algorithm. In particular, the Depth First Search algorithm
+  and the Undirected DFS algorithm implemented by Boost.Graph.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/depth_first_search.html
@@ -28,7 +29,7 @@ a particular depth.
 
 **The main Characteristics are:**
 
-- Works on both Undirected and Directed Graphs.
+- The implementation works for both undirected and directed graphs.
 - Provides the Depth First Search traversal order from a source node to
   a particular max depth level.
 - Depth First Search Running time: :math:`O(E + V)`

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -10,9 +10,9 @@
 pgr_depthFirstSearch - Experimental
 ===============================================================================
 
-``pgr_depthFirstSearch`` — Returns the traversal order(s) using Depth
-  First Search algorithm. In particular, the Depth First Search algorithm
-  and the Undirected DFS algorithm implemented by Boost.Graph.
+``pgr_depthFirstSearch`` — Returns the traversal order(s) using Depth First
+Search algorithm. In particular, the Depth First Search algorithm and the
+Undirected DFS algorithm implemented by Boost.Graph.
 
 .. figure:: images/boost-inside.jpeg
    :target: https://www.boost.org/libs/graph/doc/depth_first_search.html

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -19,6 +19,10 @@ pgr_depthFirstSearch - Experimental
 
    Boost Graph Inside
 
+.. include:: experimental.rst
+   :start-after: begin-warn-expr
+   :end-before: end-warn-exp
+
 .. rubric:: Availability
 
 Description

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -70,8 +70,8 @@ Single vertex
 :Example: From start vertex :math:`2` on a **directed** graph
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: --q1
-   :end-before: --q2
+   :start-after: -- q1
+   :end-before: -- q2
 
 .. index::
     single: depthFirstSearch(Multiple vertices)
@@ -89,8 +89,8 @@ Multiple vertices
           on a **directed** graph
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: --q2
-   :end-before: --q3
+   :start-after: -- q2
+   :end-before: -- q3
 
 .. Parameters, Inner query & result columns
 

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -29,7 +29,7 @@ Description
 -------------------------------------------------------------------------------
 
 Depth First Search algorithm is a well known traversal algorithm which starts
-from a root vertex (``start_vid``) and visits all the nodes in a graph in the
+from a start vertex (``start_vid``) and visits all the nodes in a graph in the
 depth-first search traversal order. An optional non-negative maximum depth
 parameter (``max_depth``) can be specified to get the results upto a particular
 depth.
@@ -48,12 +48,24 @@ depth.
 Signatures
 -------------------------------------------------------------------------------
 
+.. rubric:: Summary
+
 .. code-block:: none
 
-    pgr_depthFirstSearch(Edges SQL, Root vid [, max_depth] [, directed])
-    pgr_depthFirstSearch(Edges SQL, Root vids [, max_depth] [, directed])
+    pgr_depthFirstSearch(edges_sql, start_vid [, max_depth] [, directed])
+    pgr_depthFirstSearch(edges_sql, start_vids [, max_depth] [, directed])
 
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
+
+.. rubric:: Using defaults
+
+.. code-block:: none
+
+    pgr_depthFirstSearch(TEXT edges_sql, BIGINT start_vid)
+
+    RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 .. index::
     single: depthFirstSearch(Single vertex)
@@ -63,9 +75,11 @@ Single vertex
 
 .. code-block:: none
 
-    pgr_depthFirstSearch(Edges SQL, Root vid [, max_depth] [, directed])
+    pgr_depthFirstSearch(TEXT edges_sql, BIGINT start_vid,
+    BIGINT max_depth := 9223372036854775807, BOOLEAN directed := true)
 
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 :Example: From start vertex :math:`2` on a **directed** graph
 
@@ -81,9 +95,11 @@ Multiple vertices
 
 .. code-block:: none
 
-    pgr_depthFirstSearch(Edges SQL, Root vids [, max_depth] [, directed])
+    pgr_depthFirstSearch(TEXT edges_sql, ARRAY[ANY_INTEGER] start_vids,
+    BIGINT max_depth := 9223372036854775807, BOOLEAN directed := true)
 
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
+    OR EMPTY SET
 
 :Example: From start vertices :math:`\{11, 12\}` with :math:`depth <= 2`
           on a **directed** graph
@@ -102,12 +118,12 @@ Parameters
 =================== ====================== =================================================
 Parameter           Type                   Description
 =================== ====================== =================================================
-**Edges SQL**       ``TEXT``               SQL query described in `Inner query`_.
-**Root vid**        ``BIGINT``             Identifier of the root vertex of the tree.
+**edges_sql**       ``TEXT``               SQL query described in `Inner query`_.
+**start_vid**       ``BIGINT``             Identifier of the start vertex of the tree.
 
                                            - Used on `Single Vertex`_.
 
-**Root vids**       ``ARRAY[ANY-INTEGER]`` Array of identifiers of the root vertices.
+**start_vids**      ``ARRAY[ANY-INTEGER]`` Array of identifiers of the start vertices.
 
                                            - Used on `Multiple Vertices`_.
                                            - For optimization purposes, any duplicated value is ignored.
@@ -130,7 +146,7 @@ Parameter           Type        Default                     Description
 Inner query
 -------------------------------------------------------------------------------
 
-.. rubric::Edges SQL
+.. rubric:: edges_sql
 
 .. include:: pgRouting-concepts.rst
    :start-after: basic_edges_sql_start
@@ -151,7 +167,7 @@ Column           Type        Description
 
                              - :math:`0`  when ``node`` = ``start_vid``.
 
-**start_vid**    ``BIGINT``  Identifier of the root vertex.
+**start_vid**    ``BIGINT``  Identifier of the start vertex.
 
                              - In `Multiple Vertices`_ results are in ascending order.
 

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -67,6 +67,12 @@ Signatures
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
     OR EMPTY SET
 
+:Example: From start vertex :math:`2` on a **directed** graph
+
+.. literalinclude:: doc-pgr_depthFirstSearch.queries
+   :start-after: -- q1
+   :end-before: -- q2
+
 .. index::
     single: depthFirstSearch(Single vertex)
 
@@ -81,11 +87,11 @@ Single vertex
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
     OR EMPTY SET
 
-:Example: From start vertex :math:`2` on a **directed** graph
+:Example: From start vertex :math:`2` on an **undirected** graph
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q1
-   :end-before: -- q2
+   :start-after: -- q2
+   :end-before: -- q3
 
 .. index::
     single: depthFirstSearch(Multiple vertices)
@@ -105,8 +111,8 @@ Multiple vertices
           on a **directed** graph
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q2
-   :end-before: -- q3
+   :start-after: -- q3
+   :end-before: -- q4
 
 .. Parameters, Inner query & result columns
 
@@ -200,8 +206,8 @@ The examples in this section use the following:
 * :ref:`fig1`
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q3
-   :end-before: -- q4
+   :start-after: -- q5
+   :end-before: -- q6
 
 **Undirected Graph**
 
@@ -212,16 +218,16 @@ The examples in this section use the following:
 * :ref:`fig2`
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q4
-   :end-before: -- q5
+   :start-after: -- q7
+   :end-before: -- q8
 
 **Vertex Out Of Graph**
 
 :Example: For queries in which starting vertex is not present in the graph
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q5
-   :end-before: -- q6
+   :start-after: -- q9
+   :end-before: -- q10
 
 Equivalences between signatures
 ...............................................................................
@@ -233,8 +239,8 @@ The examples in this section use the following:
 * :ref:`fig1`
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q6
-   :end-before: -- q7
+   :start-after: -- q11
+   :end-before: -- q12
 
 :Examples: For queries marked as ``undirected`` with ``cost`` and ``reverse_cost`` columns
 
@@ -243,8 +249,8 @@ The examples in this section use the following:
 * :ref:`fig2`
 
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
-   :start-after: -- q7
-   :end-before: -- q8
+   :start-after: -- q13
+   :end-before: -- q14
 
 
 See Also

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -65,7 +65,6 @@ Single vertex
 
 :Example: From start vertex :math:`2` on a **directed** graph
 
-.. TODO:
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: --q1
    :end-before: --q2
@@ -85,7 +84,6 @@ Multiple vertices
 :Example: From start vertices :math:`\{11, 12\}` with :math:`depth <= 2`
           on a **directed** graph
 
-.. TODO:
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: --q2
    :end-before: --q3
@@ -170,8 +168,8 @@ Additional Examples
 
 The examples of this section are based on the :doc:`sampledata` network.
 
-.. TODO: CHANGE THIS
-   The examples include combinations ... in a directed and undirected graph.
+The examples include the traversal with starting vertices as 6, 8 and 15 in a
+directed and undirected graph, for both single vertex and multiple vertices.
 
 **Directed Graph**
 
@@ -181,7 +179,6 @@ The examples in this section use the following:
 
 * :ref:`fig1`
 
-.. TODO
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q3
    :end-before: -- q4
@@ -194,7 +191,6 @@ The examples in this section use the following:
 
 * :ref:`fig2`
 
-.. TODO
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q4
    :end-before: -- q5
@@ -203,7 +199,6 @@ The examples in this section use the following:
 
 :Example: For queries in which starting vertex is not present in the graph
 
-.. TODO:
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: --q5
    :end-before: --q6
@@ -217,7 +212,6 @@ The examples in this section use the following:
 
 * :ref:`fig1`
 
-.. TODO
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q6
    :end-before: -- q7
@@ -228,7 +222,6 @@ The examples in this section use the following:
 
 * :ref:`fig2`
 
-.. TODO
 .. literalinclude:: doc-pgr_dijkstra.queries
    :start-after: -- q7
    :end-before: -- q8

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -183,7 +183,7 @@ The examples in this section use the following:
 
 * :ref:`fig1`
 
-.. literalinclude:: doc-pgr_dijkstra.queries
+.. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q3
    :end-before: -- q4
 
@@ -195,7 +195,7 @@ The examples in this section use the following:
 
 * :ref:`fig2`
 
-.. literalinclude:: doc-pgr_dijkstra.queries
+.. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q4
    :end-before: -- q5
 
@@ -216,7 +216,7 @@ The examples in this section use the following:
 
 * :ref:`fig1`
 
-.. literalinclude:: doc-pgr_dijkstra.queries
+.. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q6
    :end-before: -- q7
 
@@ -226,7 +226,7 @@ The examples in this section use the following:
 
 * :ref:`fig2`
 
-.. literalinclude:: doc-pgr_dijkstra.queries
+.. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: -- q7
    :end-before: -- q8
 

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -24,14 +24,21 @@ pgr_depthFirstSearch - Experimental
 Description
 -------------------------------------------------------------------------------
 
-Visits the nodes in Depth First Search ordering from a root vertex to
-a particular depth.
+Depth First Search algorithm is a well known traversal algorithm which starts
+from a root vertex (``start_vid``) and visits all the nodes in a graph in the
+depth-first search traversal order. An optional non-negative maximum depth
+parameter (``max_depth``) can be specified to get the results upto a particular
+depth.
 
 **The main Characteristics are:**
 
 - The implementation works for both undirected and directed graphs.
 - Provides the Depth First Search traversal order from a source node to
-  a particular max depth level.
+  a particular maximum depth level.
+- For optimization purposes, any duplicated values in the `start_vids` are
+  ignored.
+- The returned values are ordered in ascending order of `start_vid`.
+- If the starting vertex does not exist, empty row is returned.
 - Depth First Search Running time: :math:`O(E + V)`
 
 Signatures
@@ -56,8 +63,9 @@ Single vertex
 
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example: The Minimum Spanning Tree having as root vertex :math:`2`
+:Example: From start vertex :math:`2` on a **directed** graph
 
+.. TODO:
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: --q1
    :end-before: --q2
@@ -74,8 +82,10 @@ Multiple vertices
 
     RETURNS SET OF (seq, depth, start_vid, node, edge, cost, agg_cost)
 
-:Example:
+:Example: From start vertices :math:`\{11, 12\}` with :math:`depth <= 2`
+          on a **directed** graph
 
+.. TODO:
 .. literalinclude:: doc-pgr_depthFirstSearch.queries
    :start-after: --q2
    :end-before: --q3
@@ -83,6 +93,7 @@ Multiple vertices
 .. Parameters, Inner query & result columns
 
 .. depthFirstSearch-information-start
+
 
 
 

--- a/doc/depthFirstSearch/pgr_depthFirstSearch.rst
+++ b/doc/depthFirstSearch/pgr_depthFirstSearch.rst
@@ -94,6 +94,76 @@ Multiple vertices
 
 .. depthFirstSearch-information-start
 
+Parameters
+-------------------------------------------------------------------------------
+
+=================== ====================== =================================================
+Parameter           Type                   Description
+=================== ====================== =================================================
+**Edges SQL**       ``TEXT``               SQL query described in `Inner query`_.
+**Root vid**        ``BIGINT``             Identifier of the root vertex of the tree.
+
+                                           - Used on `Single Vertex`_.
+
+**Root vids**       ``ARRAY[ANY-INTEGER]`` Array of identifiers of the root vertices.
+
+                                           - Used on `Multiple Vertices`_.
+                                           - For optimization purposes, any duplicated value is ignored.
+=================== ====================== =================================================
+
+Optional Parameters
+...............................................................................
+
+=================== =========== =========================== =================================================
+Parameter           Type        Default                     Description
+=================== =========== =========================== =================================================
+**max_depth**       ``BIGINT``  :math:`9223372036854775807` Upper limit for depth of node in the tree
+
+                                                            - When value is ``Negative`` then **throws error**
+
+**directed**        ``BOOLEAN`` ``true``                    - When ``true`` Graph is considered `Directed`
+                                                            - When ``false`` the graph is considered as `Undirected`.
+=================== =========== =========================== =================================================
+
+Inner query
+-------------------------------------------------------------------------------
+
+.. rubric::Edges SQL
+
+.. include:: pgRouting-concepts.rst
+   :start-after: basic_edges_sql_start
+   :end-before: basic_edges_sql_end
+
+Result Columns
+-------------------------------------------------------------------------------
+
+.. result columns start
+
+Returns SET OF ``(seq, depth, start_vid, node, edge, cost, agg_cost)``
+
+===============  =========== ====================================================
+Column           Type        Description
+===============  =========== ====================================================
+**seq**          ``BIGINT``  Sequential value starting from :math:`1`.
+**depth**        ``BIGINT``  Depth of the ``node``.
+
+                             - :math:`0`  when ``node`` = ``start_vid``.
+
+**start_vid**    ``BIGINT``  Identifier of the root vertex.
+
+                             - In `Multiple Vertices`_ results are in ascending order.
+
+**node**         ``BIGINT``  Identifier of ``node`` reached using ``edge``.
+**edge**         ``BIGINT``  Identifier of the ``edge`` used to arrive to ``node``.
+
+                             - :math:`-1`  when ``node`` = ``start_vid``.
+
+**cost**         ``FLOAT``   Cost to traverse ``edge``.
+**agg_cost**     ``FLOAT``   Aggregate cost from ``start_vid`` to ``node``.
+===============  =========== ====================================================
+
+.. result columns end
+
 
 
 

--- a/doc/src/pgRouting-introduction.rst
+++ b/doc/src/pgRouting-introduction.rst
@@ -49,6 +49,7 @@ Individuals (in alphabetical order)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Aasheesh Tiwari, Aditya Pratap Singh, Adrien Berchet,
+Ashish Kumar,
 Cayetano Benavent,
 Gudesa Venkata Sai Akhil,
 Hang Wu,
@@ -79,6 +80,7 @@ Individuals (in alphabetical order)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Aasheesh Tiwari, Aditya Pratap Singh, Adrien Berchet, Akio Takubo, Andrea Nardelli, Anthony Tasca, Anton Patrushev, Ashraf Hossain,
+Ashish Kumar,
 Cayetano Benavent, Christian Gonzalez,
 Daniel Kastl, Dave Potts, David Techer, Denis Rykov,
 Ema Miyawaki,

--- a/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.result
+++ b/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.result
@@ -12,6 +12,7 @@ CREATE TABLE sample_table (
 );
 CREATE TABLE
 -- SAMPLE TABLE CREATE end
+
 -- SAMPLE TABLE ADD DATA start
 INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
     (3, 6, 20, 15),
@@ -19,6 +20,7 @@ INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
     (6, 8, -1, 12);
 INSERT 0 3
 -- SAMPLE TABLE ADD DATA end
+
 -- q0
 SELECT * FROM sample_table ORDER BY id;
  id | source | target | cost | reverse_cost

--- a/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.result
+++ b/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.result
@@ -1,0 +1,127 @@
+BEGIN;
+BEGIN
+SET client_min_messages TO NOTICE;
+SET
+-- SAMPLE TABLE CREATE start
+CREATE TABLE sample_table (
+    id BIGSERIAL,
+    source BIGINT,
+    target BIGINT,
+    cost FLOAT,
+    reverse_cost FLOAT
+);
+CREATE TABLE
+-- SAMPLE TABLE CREATE end
+-- SAMPLE TABLE ADD DATA start
+INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
+    (3, 6, 20, 15),
+    (3, 8, 10, -10),
+    (6, 8, -1, 12);
+INSERT 0 3
+-- SAMPLE TABLE ADD DATA end
+-- q0
+SELECT * FROM sample_table ORDER BY id;
+ id | source | target | cost | reverse_cost
+----+--------+--------+------+--------------
+  1 |      3 |      6 |   20 |           15
+  2 |      3 |      8 |   10 |          -10
+  3 |      6 |      8 |   -1 |           12
+(3 rows)
+
+-- q1
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    3
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         3 |    3 |   -1 |    0 |        0
+   2 |     1 |         3 |    6 |    1 |   20 |       20
+   3 |     1 |         3 |    8 |    2 |   10 |       10
+(3 rows)
+
+-- q2
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         6 |    6 |   -1 |    0 |        0
+   2 |     1 |         6 |    3 |    1 |   15 |       15
+   3 |     2 |         6 |    8 |    2 |   10 |       25
+(3 rows)
+
+-- q3
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6, max_depth := 1
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         6 |    6 |   -1 |    0 |        0
+   2 |     1 |         6 |    3 |    1 |   15 |       15
+(2 rows)
+
+-- q4
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    2
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+(0 rows)
+
+-- q5
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    3, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         3 |    3 |   -1 |    0 |        0
+   2 |     1 |         3 |    6 |    1 |   20 |       20
+   3 |     2 |         3 |    8 |    3 |   12 |       32
+(3 rows)
+
+-- q6
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         6 |    6 |   -1 |    0 |        0
+   2 |     1 |         6 |    3 |    1 |   20 |       20
+   3 |     2 |         6 |    8 |    2 |   10 |       30
+(3 rows)
+
+-- q7
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6, max_depth := 1, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         6 |    6 |   -1 |    0 |        0
+   2 |     1 |         6 |    3 |    1 |   20 |       20
+(2 rows)
+
+-- q8
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    ARRAY[6, 3, 6]
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         3 |    3 |   -1 |    0 |        0
+   2 |     1 |         3 |    6 |    1 |   20 |       20
+   3 |     1 |         3 |    8 |    2 |   10 |       10
+   4 |     0 |         6 |    6 |   -1 |    0 |        0
+   5 |     1 |         6 |    3 |    1 |   15 |       15
+   6 |     2 |         6 |    8 |    2 |   10 |       25
+(6 rows)
+
+-- q9
+ROLLBACK;
+ROLLBACK

--- a/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.test.sql
+++ b/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.test.sql
@@ -7,6 +7,7 @@ CREATE TABLE sample_table (
     reverse_cost FLOAT
 );
 \echo -- SAMPLE TABLE CREATE end
+\echo
 
 \echo -- SAMPLE TABLE ADD DATA start
 INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
@@ -14,6 +15,7 @@ INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
     (3, 8, 10, -10),
     (6, 8, -1, 12);
 \echo -- SAMPLE TABLE ADD DATA end
+\echo
 
 -- SELECT query on SAMPLE TABLE
 \echo -- q0

--- a/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.test.sql
+++ b/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.test.sql
@@ -14,3 +14,64 @@ INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
     (3, 8, 10, -10),
     (6, 8, -1, 12);
 \echo -- SAMPLE TABLE ADD DATA end
+
+-- SELECT query on SAMPLE TABLE
+\echo -- q0
+SELECT * FROM sample_table ORDER BY id;
+
+-- Directed Graph with start_vid 3
+\echo -- q1
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    3
+);
+
+-- Directed Graph with start_vid 6
+\echo -- q2
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6
+);
+
+-- Directed Graph with start_vid 6 and max_depth 1
+\echo -- q3
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6, max_depth := 1
+);
+
+-- start_vid does not exist in the Graph
+\echo -- q4
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    2
+);
+
+-- Undirected Graph with start_vid 3
+\echo -- q5
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    3, directed := false
+);
+
+-- Undirected Graph with start_vid 6
+\echo -- q6
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6, directed := false
+);
+
+-- Undirected Graph with start_vid 6 and max_depth 1
+\echo -- q7
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    6, max_depth := 1, directed := false
+);
+
+-- Directed Graph with multiple start_vids
+\echo -- q8
+SELECT * FROM pgr_depthFirstSearch (
+    'SELECT id, source, target, cost, reverse_cost FROM sample_table ORDER BY id',
+    ARRAY[6, 3, 6]
+);
+\echo -- q9

--- a/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.test.sql
+++ b/docqueries/depthFirstSearch/depthFirstSearch-issue1348-usage.test.sql
@@ -1,0 +1,16 @@
+\echo -- SAMPLE TABLE CREATE start
+CREATE TABLE sample_table (
+    id BIGSERIAL,
+    source BIGINT,
+    target BIGINT,
+    cost FLOAT,
+    reverse_cost FLOAT
+);
+\echo -- SAMPLE TABLE CREATE end
+
+\echo -- SAMPLE TABLE ADD DATA start
+INSERT INTO sample_table (source, target, cost, reverse_cost) VALUES
+    (3, 6, 20, 15),
+    (3, 8, 10, -10),
+    (6, 8, -1, 12);
+\echo -- SAMPLE TABLE ADD DATA end

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -62,7 +62,6 @@ SELECT * FROM pgr_depthFirstSearch(
   13 |     3 |         6 |   13 |   14 |    1 |        3
 (13 rows)
 
---q4
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15]
@@ -86,7 +85,6 @@ SELECT * FROM pgr_depthFirstSearch(
   15 |     1 |        15 |   14 |   17 |    1 |        1
 (15 rows)
 
---q5
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2
@@ -103,7 +101,7 @@ SELECT * FROM pgr_depthFirstSearch(
    8 |     1 |        15 |   14 |   17 |    1 |        1
 (8 rows)
 
---q6
+--q4
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6, directed := false
@@ -125,7 +123,6 @@ SELECT * FROM pgr_depthFirstSearch(
   13 |     5 |         6 |   13 |   14 |    1 |        5
 (13 rows)
 
---q7
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], directed := false
@@ -149,7 +146,6 @@ SELECT * FROM pgr_depthFirstSearch(
   15 |     1 |        15 |   14 |   17 |    1 |        1
 (15 rows)
 
---q8
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2, directed := false
@@ -164,6 +160,6 @@ SELECT * FROM pgr_depthFirstSearch(
    6 |     1 |        15 |   14 |   17 |    1 |        1
 (6 rows)
 
---q9
+--q5
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -104,5 +104,66 @@ SELECT * FROM pgr_depthFirstSearch(
 (8 rows)
 
 --q6
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    6, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         6 |    6 |   -1 |    0 |        0
+   2 |     1 |         6 |    3 |    5 |    1 |        1
+   3 |     2 |         6 |    2 |    2 |    1 |        2
+   4 |     3 |         6 |    1 |    1 |    1 |        3
+   5 |     3 |         6 |    5 |    4 |    1 |        3
+   6 |     4 |         6 |    8 |    7 |    1 |        4
+   7 |     5 |         6 |    7 |    6 |    1 |        5
+   8 |     4 |         6 |   10 |   10 |    1 |        4
+   9 |     5 |         6 |   11 |   12 |    1 |        5
+  10 |     6 |         6 |   12 |   13 |    1 |        6
+  11 |     7 |         6 |    9 |   15 |    1 |        7
+  12 |     8 |         6 |    4 |   16 |    1 |        8
+  13 |     5 |         6 |   13 |   14 |    1 |        5
+(13 rows)
+
+--q7
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15], directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         8 |    8 |   -1 |    0 |        0
+   2 |     1 |         8 |    7 |    6 |    1 |        1
+   3 |     1 |         8 |    5 |    7 |    1 |        1
+   4 |     2 |         8 |    2 |    4 |    1 |        2
+   5 |     3 |         8 |    1 |    1 |    1 |        3
+   6 |     3 |         8 |    3 |    2 |    1 |        3
+   7 |     4 |         8 |    4 |    3 |    1 |        4
+   8 |     5 |         8 |    9 |   16 |    1 |        5
+   9 |     6 |         8 |    6 |    9 |    1 |        6
+  10 |     7 |         8 |   11 |   11 |    1 |        7
+  11 |     8 |         8 |   10 |   12 |    1 |        8
+  12 |     9 |         8 |   13 |   14 |    1 |        9
+  13 |     8 |         8 |   12 |   13 |    1 |        8
+  14 |     0 |        15 |   15 |   -1 |    0 |        0
+  15 |     1 |        15 |   14 |   17 |    1 |        1
+(15 rows)
+
+--q8
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15], max_depth := 2, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         8 |    8 |   -1 |    0 |        0
+   2 |     1 |         8 |    7 |    6 |    1 |        1
+   3 |     1 |         8 |    5 |    7 |    1 |        1
+   4 |     2 |         8 |    2 |    4 |    1 |        2
+   5 |     0 |        15 |   15 |   -1 |    0 |        0
+   6 |     1 |        15 |   14 |   17 |    1 |        1
+(6 rows)
+
+--q9
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -27,6 +27,28 @@ SELECT * FROM pgr_depthFirstSearch(
 -- q2
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    2, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         2 |    2 |   -1 |    0 |        0
+   2 |     1 |         2 |    1 |    1 |    1 |        1
+   3 |     1 |         2 |    3 |    2 |    1 |        1
+   4 |     2 |         2 |    4 |    3 |    1 |        2
+   5 |     3 |         2 |    9 |   16 |    1 |        3
+   6 |     4 |         2 |    6 |    9 |    1 |        4
+   7 |     5 |         2 |    5 |    8 |    1 |        5
+   8 |     6 |         2 |    8 |    7 |    1 |        6
+   9 |     7 |         2 |    7 |    6 |    1 |        7
+  10 |     6 |         2 |   10 |   10 |    1 |        6
+  11 |     7 |         2 |   11 |   12 |    1 |        7
+  12 |     8 |         2 |   12 |   13 |    1 |        8
+  13 |     7 |         2 |   13 |   14 |    1 |        7
+(13 rows)
+
+-- q3
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[11,12], max_depth := 2
 );
  seq | depth | start_vid | node | edge | cost | agg_cost
@@ -40,8 +62,8 @@ SELECT * FROM pgr_depthFirstSearch(
    7 |     2 |        12 |    4 |   16 |    1 |        2
 (7 rows)
 
--- q3
 -- q4
+-- q5
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6
@@ -102,8 +124,8 @@ SELECT * FROM pgr_depthFirstSearch(
    8 |     1 |        15 |   14 |   17 |    1 |        1
 (8 rows)
 
--- q5
 -- q6
+-- q7
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6, directed := false
@@ -162,8 +184,8 @@ SELECT * FROM pgr_depthFirstSearch(
    6 |     1 |        15 |   14 |   17 |    1 |        1
 (6 rows)
 
--- q7
 -- q8
+-- q9
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[-10,20]
@@ -172,8 +194,8 @@ SELECT * FROM pgr_depthFirstSearch(
 -----+-------+-----------+------+------+------+----------
 (0 rows)
 
--- q9
 -- q10
+-- q11
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16
@@ -224,8 +246,8 @@ SELECT * FROM pgr_depthFirstSearch(
    2 |     1 |        16 |   17 |   18 |    1 |        1
 (2 rows)
 
--- q11
 -- q12
+-- q13
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16, directed := false
@@ -266,6 +288,6 @@ SELECT * FROM pgr_depthFirstSearch(
    2 |     1 |        16 |   17 |   18 |    1 |        1
 (2 rows)
 
--- q13
+-- q14
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -160,6 +160,15 @@ SELECT * FROM pgr_depthFirstSearch(
    6 |     1 |        15 |   14 |   17 |    1 |        1
 (6 rows)
 
---q5
+-- q5
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[-10,20]
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+(0 rows)
+
+--q6
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -2,5 +2,44 @@ BEGIN;
 BEGIN
 SET client_min_messages TO NOTICE;
 SET
+--q1
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    2
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         2 |    2 |   -1 |    0 |        0
+   2 |     1 |         2 |    1 |    1 |    1 |        1
+   3 |     1 |         2 |    5 |    4 |    1 |        1
+   4 |     2 |         2 |    8 |    7 |    1 |        2
+   5 |     3 |         2 |    7 |    6 |    1 |        3
+   6 |     2 |         2 |    6 |    8 |    1 |        2
+   7 |     3 |         2 |    9 |    9 |    1 |        3
+   8 |     4 |         2 |   12 |   15 |    1 |        4
+   9 |     4 |         2 |    4 |   16 |    1 |        4
+  10 |     5 |         2 |    3 |    3 |    1 |        5
+  11 |     3 |         2 |   11 |   11 |    1 |        3
+  12 |     2 |         2 |   10 |   10 |    1 |        2
+  13 |     3 |         2 |   13 |   14 |    1 |        3
+(13 rows)
+
+--q2
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[11,12], max_depth := 2
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        11 |   11 |   -1 |    0 |        0
+   2 |     1 |        11 |   12 |   13 |    1 |        1
+   3 |     2 |        11 |    9 |   15 |    1 |        2
+   4 |     0 |        12 |   12 |   -1 |    0 |        0
+   5 |     1 |        12 |    9 |   15 |    1 |        1
+   6 |     2 |        12 |    6 |    9 |    1 |        2
+   7 |     2 |        12 |    4 |   16 |    1 |        2
+(7 rows)
+
+--q3
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -221,5 +221,46 @@ SELECT * FROM pgr_depthFirstSearch(
 (2 rows)
 
 -- q7
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16], directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, max_depth := 1, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16], max_depth := 5, directed := false
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+-- q8
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -170,5 +170,56 @@ SELECT * FROM pgr_depthFirstSearch(
 (0 rows)
 
 --q6
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, directed := true
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16]
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, max_depth := 1
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16], max_depth := 5
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |        16 |   16 |   -1 |    0 |        0
+   2 |     1 |        16 |   17 |   18 |    1 |        1
+(2 rows)
+
+-- q7
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -2,7 +2,7 @@ BEGIN;
 BEGIN
 SET client_min_messages TO NOTICE;
 SET
---q1
+-- q1
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     2
@@ -24,7 +24,7 @@ SELECT * FROM pgr_depthFirstSearch(
   13 |     3 |         2 |   13 |   14 |    1 |        3
 (13 rows)
 
---q2
+-- q2
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[11,12], max_depth := 2
@@ -40,7 +40,8 @@ SELECT * FROM pgr_depthFirstSearch(
    7 |     2 |        12 |    4 |   16 |    1 |        2
 (7 rows)
 
---q3
+-- q3
+-- q4
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6
@@ -101,7 +102,8 @@ SELECT * FROM pgr_depthFirstSearch(
    8 |     1 |        15 |   14 |   17 |    1 |        1
 (8 rows)
 
---q4
+-- q5
+-- q6
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6, directed := false
@@ -160,7 +162,8 @@ SELECT * FROM pgr_depthFirstSearch(
    6 |     1 |        15 |   14 |   17 |    1 |        1
 (6 rows)
 
--- q5
+-- q7
+-- q8
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[-10,20]
@@ -169,7 +172,8 @@ SELECT * FROM pgr_depthFirstSearch(
 -----+-------+-----------+------+------+------+----------
 (0 rows)
 
---q6
+-- q9
+-- q10
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16
@@ -220,7 +224,8 @@ SELECT * FROM pgr_depthFirstSearch(
    2 |     1 |        16 |   17 |   18 |    1 |        1
 (2 rows)
 
--- q7
+-- q11
+-- q12
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16, directed := false
@@ -261,6 +266,6 @@ SELECT * FROM pgr_depthFirstSearch(
    2 |     1 |        16 |   17 |   18 |    1 |        1
 (2 rows)
 
--- q8
+-- q13
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.result
@@ -41,5 +41,68 @@ SELECT * FROM pgr_depthFirstSearch(
 (7 rows)
 
 --q3
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    6
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         6 |    6 |   -1 |    0 |        0
+   2 |     1 |         6 |    5 |    8 |    1 |        1
+   3 |     2 |         6 |    2 |    4 |    1 |        2
+   4 |     3 |         6 |    1 |    1 |    1 |        3
+   5 |     2 |         6 |    8 |    7 |    1 |        2
+   6 |     3 |         6 |    7 |    6 |    1 |        3
+   7 |     2 |         6 |   10 |   10 |    1 |        2
+   8 |     3 |         6 |   11 |   12 |    1 |        3
+   9 |     4 |         6 |   12 |   13 |    1 |        4
+  10 |     5 |         6 |    9 |   15 |    1 |        5
+  11 |     6 |         6 |    4 |   16 |    1 |        6
+  12 |     7 |         6 |    3 |    3 |    1 |        7
+  13 |     3 |         6 |   13 |   14 |    1 |        3
+(13 rows)
+
+--q4
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15]
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         8 |    8 |   -1 |    0 |        0
+   2 |     1 |         8 |    7 |    6 |    1 |        1
+   3 |     1 |         8 |    5 |    7 |    1 |        1
+   4 |     2 |         8 |    2 |    4 |    1 |        2
+   5 |     3 |         8 |    1 |    1 |    1 |        3
+   6 |     2 |         8 |    6 |    8 |    1 |        2
+   7 |     3 |         8 |    9 |    9 |    1 |        3
+   8 |     4 |         8 |   12 |   15 |    1 |        4
+   9 |     4 |         8 |    4 |   16 |    1 |        4
+  10 |     5 |         8 |    3 |    3 |    1 |        5
+  11 |     3 |         8 |   11 |   11 |    1 |        3
+  12 |     2 |         8 |   10 |   10 |    1 |        2
+  13 |     3 |         8 |   13 |   14 |    1 |        3
+  14 |     0 |        15 |   15 |   -1 |    0 |        0
+  15 |     1 |        15 |   14 |   17 |    1 |        1
+(15 rows)
+
+--q5
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15], max_depth := 2
+);
+ seq | depth | start_vid | node | edge | cost | agg_cost
+-----+-------+-----------+------+------+------+----------
+   1 |     0 |         8 |    8 |   -1 |    0 |        0
+   2 |     1 |         8 |    7 |    6 |    1 |        1
+   3 |     1 |         8 |    5 |    7 |    1 |        1
+   4 |     2 |         8 |    2 |    4 |    1 |        2
+   5 |     2 |         8 |    6 |    8 |    1 |        2
+   6 |     2 |         8 |   10 |   10 |    1 |        2
+   7 |     0 |        15 |   15 |   -1 |    0 |        0
+   8 |     1 |        15 |   14 |   17 |    1 |        1
+(8 rows)
+
+--q6
 ROLLBACK;
 ROLLBACK

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -1,0 +1,11 @@
+\echo --q1
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    2
+);
+\echo --q2
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[11,12], max_depth := 2
+);
+\echo --q3

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -1,14 +1,20 @@
-\echo --q1
+\echo -- q1
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     2
 );
-\echo --q2
+\echo -- q2
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[11,12], max_depth := 2
 );
-\echo --q3
+\echo -- q3
+
+
+-- Examples for :ref:`fig1-direct-Cost-Reverse`
+-------------------------------------------------------------------------------
+
+\echo -- q4
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6
@@ -21,7 +27,13 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2
 );
-\echo --q4
+\echo -- q5
+
+
+-- Examples for :ref:`fig2-undirect-Cost-Reverse`
+-------------------------------------------------------------------------------
+
+\echo -- q6
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6, directed := false
@@ -34,12 +46,24 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2, directed := false
 );
-\echo --q5
+\echo -- q7
+
+
+-- Example for Vertex Out of Graph
+-------------------------------------------------------------------------------
+
+\echo -- q8
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[-10,20]
 );
-\echo --q6
+\echo -- q9
+
+
+-- Equivalences for :ref:`fig1-direct-Cost-Reverse`
+-------------------------------------------------------------------------------
+
+\echo -- q10
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16
@@ -60,7 +84,13 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[16], max_depth := 5
 );
-\echo --q7
+\echo -- q11
+
+
+-- Equivalences for :ref:`fig2-undirect-Cost-Reverse`
+-------------------------------------------------------------------------------
+
+\echo -- q12
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16, directed := false
@@ -77,4 +107,4 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[16], max_depth := 5, directed := false
 );
-\echo --q8
+\echo -- q13

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -61,3 +61,20 @@ SELECT * FROM pgr_depthFirstSearch(
     ARRAY[16], max_depth := 5
 );
 \echo --q7
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, directed := false
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16], directed := false
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, max_depth := 1, directed := false
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16], max_depth := 5, directed := false
+);
+\echo --q8

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -9,3 +9,18 @@ SELECT * FROM pgr_depthFirstSearch(
     ARRAY[11,12], max_depth := 2
 );
 \echo --q3
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    6
+);
+\echo --q4
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15]
+);
+\echo --q5
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15], max_depth := 2
+);
+\echo --q6

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -35,3 +35,8 @@ SELECT * FROM pgr_depthFirstSearch(
     ARRAY[8,15], max_depth := 2, directed := false
 );
 \echo --q5
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[-10,20]
+);
+\echo --q6

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -24,3 +24,18 @@ SELECT * FROM pgr_depthFirstSearch(
     ARRAY[8,15], max_depth := 2
 );
 \echo --q6
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    6, directed := false
+);
+\echo --q7
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15], directed := false
+);
+\echo --q8
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[8,15], max_depth := 2, directed := false
+);
+\echo --q9

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -6,15 +6,20 @@ SELECT * FROM pgr_depthFirstSearch(
 \echo -- q2
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
-    ARRAY[11,12], max_depth := 2
+    2, directed := false
 );
 \echo -- q3
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[11,12], max_depth := 2
+);
+\echo -- q4
 
 
 -- Examples for :ref:`fig1-direct-Cost-Reverse`
 -------------------------------------------------------------------------------
 
-\echo -- q4
+\echo -- q5
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6
@@ -27,13 +32,13 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2
 );
-\echo -- q5
+\echo -- q6
 
 
 -- Examples for :ref:`fig2-undirect-Cost-Reverse`
 -------------------------------------------------------------------------------
 
-\echo -- q6
+\echo -- q7
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6, directed := false
@@ -46,24 +51,24 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2, directed := false
 );
-\echo -- q7
+\echo -- q8
 
 
 -- Example for Vertex Out of Graph
 -------------------------------------------------------------------------------
 
-\echo -- q8
+\echo -- q9
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[-10,20]
 );
-\echo -- q9
+\echo -- q10
 
 
 -- Equivalences for :ref:`fig1-direct-Cost-Reverse`
 -------------------------------------------------------------------------------
 
-\echo -- q10
+\echo -- q11
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16
@@ -84,13 +89,13 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[16], max_depth := 5
 );
-\echo -- q11
+\echo -- q12
 
 
 -- Equivalences for :ref:`fig2-undirect-Cost-Reverse`
 -------------------------------------------------------------------------------
 
-\echo -- q12
+\echo -- q13
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     16, directed := false
@@ -107,4 +112,4 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[16], max_depth := 5, directed := false
 );
-\echo -- q13
+\echo -- q14

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -40,3 +40,24 @@ SELECT * FROM pgr_depthFirstSearch(
     ARRAY[-10,20]
 );
 \echo --q6
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, directed := true
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16]
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    16, max_depth := 1
+);
+SELECT * FROM pgr_depthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
+    ARRAY[16], max_depth := 5
+);
+\echo --q7

--- a/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
+++ b/docqueries/depthFirstSearch/doc-pgr_depthFirstSearch.test.sql
@@ -13,29 +13,25 @@ SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6
 );
-\echo --q4
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15]
 );
-\echo --q5
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2
 );
-\echo --q6
+\echo --q4
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     6, directed := false
 );
-\echo --q7
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], directed := false
 );
-\echo --q8
 SELECT * FROM pgr_depthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost FROM edge_table ORDER BY id',
     ARRAY[8,15], max_depth := 2, directed := false
 );
-\echo --q9
+\echo --q5

--- a/docqueries/depthFirstSearch/test.conf
+++ b/docqueries/depthFirstSearch/test.conf
@@ -6,6 +6,7 @@
         'data' => [ ],
         'tests' => [qw(
             doc-pgr_depthFirstSearch
+            depthFirstSearch-issue1348-usage
             )],
         'documentation' => [qw(
             doc-pgr_depthFirstSearch

--- a/include/depthFirstSearch/pgr_depthFirstSearch.hpp
+++ b/include/depthFirstSearch/pgr_depthFirstSearch.hpp
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <boost/graph/undirected_dfs.hpp>
 
 #include <vector>
+#include <map>
 
 #include "cpp_common/pgr_base_graph.hpp"
 #include "cpp_common/pgr_messages.h"

--- a/include/depthFirstSearch/pgr_depthFirstSearch.hpp
+++ b/include/depthFirstSearch/pgr_depthFirstSearch.hpp
@@ -45,9 +45,6 @@ class Pgr_depthFirstSearch : public pgrouting::Pgr_messages {
     typedef typename G::V V;
     typedef typename G::E E;
 
-    // TODO(ashish): Use both boost::depth_first_search and boost::undirected_dfs below,
-    //               for directed and undirected graphs.
-
     std::vector<pgr_mst_rt> depthFirstSearch(
             G &graph,
             std::vector<int64_t> roots,

--- a/src/depthFirstSearch/depthFirstSearch_driver.cpp
+++ b/src/depthFirstSearch/depthFirstSearch_driver.cpp
@@ -55,6 +55,7 @@ pgr_depthFirstSearch(
         G &graph,
         std::vector < int64_t > roots,
         int64_t max_depth,
+        bool directed,
         std::string &log) {
     std::sort(roots.begin(), roots.end());
     roots.erase(
@@ -63,7 +64,7 @@ pgr_depthFirstSearch(
 
     pgrouting::functions::Pgr_depthFirstSearch< G > fn_depthFirstSearch;
     auto results = fn_depthFirstSearch.depthFirstSearch(
-            graph, roots, max_depth);
+            graph, roots, max_depth, directed);
     log += fn_depthFirstSearch.get_log();
     return results;
 }
@@ -111,6 +112,7 @@ do_pgr_depthFirstSearch(
                     digraph,
                     roots,
                     max_depth,
+                    directed,
                     logstr);
         } else {
             log << "Working with Undirected Graph\n";
@@ -121,6 +123,7 @@ do_pgr_depthFirstSearch(
                     undigraph,
                     roots,
                     max_depth,
+                    directed,
                     logstr);
         }
         log << logstr;

--- a/src/depthFirstSearch/depthFirstSearch_driver.cpp
+++ b/src/depthFirstSearch/depthFirstSearch_driver.cpp
@@ -128,13 +128,6 @@ do_pgr_depthFirstSearch(
         }
         log << logstr;
 
-#if 0
-        pgrouting::UndirectedGraph undigraph(UNDIRECTED);
-        undigraph.insert_min_edges_no_parallel(data_edges, total_edges);
-        pgrouting::functions::Pgr_prim<pgrouting::UndirectedGraph> prim;
-        results = prim.primDFS(undigraph, roots, max_depth);
-#endif
-
         auto count = results.size();
 
         if (count == 0) {


### PR DESCRIPTION
- [x] Added boost functionality for undirected graphs by calling `boost::undirected_dfs`
- [x] Completed the documentation for `pgr_depthFirstSearch` - `doc/pgr_depthFirstSearch.rst` file
- [x] Added docqueries for the documentation using sample data
- [x] Included the docqueries in the documentation file (`.rst`)
- [x] Generated documentation locally and deployed it for preview [[deployed link](https://krashish8.github.io/GSoC-pgRouting/dev/en/pgr_depthFirstSearch.html)]
- [x] Added extra test queries using the sample table mentioned in Issue [#1348](https://github.com/pgRouting/pgrouting/issues/1348) - Usage section

**Users' Documentation:**
* [`pgr_depthFirstSearch`](https://krashish8.github.io/GSoC-pgRouting/dev/en/pgr_depthFirstSearch.html)

**Developers' Documentation:**
1. [`pgrouting::functions::Pgr_depthFirstSearch()`](https://krashish8.github.io/GSoC-pgRouting/doxy/3.0/classpgrouting_1_1functions_1_1Pgr__depthFirstSearch.html#afedc84b74ba849fe0c15177812c27662)
2. [`depthFirstSearch.c`](https://krashish8.github.io/GSoC-pgRouting/doxy/3.0/depthFirstSearch_8c.html)
3. [`depthFirstSearch_driver.cpp`](https://krashish8.github.io/GSoC-pgRouting/doxy/3.0/depthFirstSearch__driver_8cpp.html)
4. [`depthFirstSearch_driver.h`](https://krashish8.github.io/GSoC-pgRouting/doxy/3.0/depthFirstSearch__driver_8h.html)