### PR TITLE
pgr_sequentialVertexColoring GSoC-2020 Week 6

### DIFF
--- a/pgtap/depthFirstSearch/depthFirstSearch-edge-cases.sql
+++ b/pgtap/depthFirstSearch/depthFirstSearch-edge-cases.sql
@@ -127,109 +127,109 @@ SELECT id, source, target, cost, reverse_cost
 FROM edge_table;
 
 -- pgRouting Sample Data
-SELECT isnt_empty('q14', 'q14: pgRouting Sample Data');
+SELECT isnt_empty('q14', 'q15: pgRouting Sample Data');
 
 -- vertex not present in graph tests (directed)
 
-PREPARE depthFirstSearch14 AS
+PREPARE depthFirstSearch15 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     -10
 );
 
-PREPARE depthFirstSearch15 AS
+PREPARE depthFirstSearch16 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[-10]
 );
 
-PREPARE depthFirstSearch16 AS
+PREPARE depthFirstSearch17 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[20, -10]
 );
 
-PREPARE depthFirstSearch17 AS
+PREPARE depthFirstSearch18 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     -10, max_depth => 2
 );
 
-PREPARE depthFirstSearch18 AS
+PREPARE depthFirstSearch19 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[-10], max_depth => 2
 );
 
-PREPARE depthFirstSearch19 AS
+PREPARE depthFirstSearch20 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[20, -10], max_depth => 2
 );
 
-SELECT is_empty('depthFirstSearch14', '14: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch15', '15: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch16', '16: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch17', '17: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch18', '18: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch19', '19: Vertex not present in graph -> Empty row is returned');
+SELECT is_empty('depthFirstSearch20', '20: Vertex not present in graph -> Empty row is returned');
 
 -- vertex not present in graph tests (undirected)
 
-PREPARE depthFirstSearch20 AS
+PREPARE depthFirstSearch21 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     -10, directed => false
 );
 
-PREPARE depthFirstSearch21 AS
+PREPARE depthFirstSearch22 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[-10], directed => false
 );
 
-PREPARE depthFirstSearch22 AS
+PREPARE depthFirstSearch23 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[20, -10], directed => false
 );
 
-PREPARE depthFirstSearch23 AS
+PREPARE depthFirstSearch24 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     -10, max_depth => 2, directed => false
 );
 
-PREPARE depthFirstSearch24 AS
+PREPARE depthFirstSearch25 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[-10], max_depth => 2, directed => false
 );
 
-PREPARE depthFirstSearch25 AS
+PREPARE depthFirstSearch26 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[20, -10], max_depth => 2, directed => false
 );
 
-SELECT is_empty('depthFirstSearch20', '20: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch21', '21: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch22', '22: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch23', '23: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch24', '24: Vertex not present in graph -> Empty row is returned');
 SELECT is_empty('depthFirstSearch25', '25: Vertex not present in graph -> Empty row is returned');
+SELECT is_empty('depthFirstSearch26', '26: Vertex not present in graph -> Empty row is returned');
 
 
 
@@ -238,54 +238,54 @@ SELECT is_empty('depthFirstSearch25', '25: Vertex not present in graph -> Empty 
 
 -- negative depth tests
 
-PREPARE depthFirstSearch26 AS
+PREPARE depthFirstSearch27 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     4, max_depth => -3
 );
 
-PREPARE depthFirstSearch27 AS
+PREPARE depthFirstSearch28 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[4], max_depth => -3
 );
 
-PREPARE depthFirstSearch28 AS
+PREPARE depthFirstSearch29 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[4, 20], max_depth => -3
 );
 
-PREPARE depthFirstSearch29 AS
+PREPARE depthFirstSearch30 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     4, max_depth => -3, directed => false
 );
 
-PREPARE depthFirstSearch30 AS
+PREPARE depthFirstSearch31 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[4], max_depth => -3, directed => false
 );
 
-PREPARE depthFirstSearch31 AS
+PREPARE depthFirstSearch32 AS
 SELECT *
 FROM pgr_depthFirstSearch(
     'q14',
     ARRAY[4, 20], max_depth => -3, directed => false
 );
 
-SELECT throws_ok('depthFirstSearch26', 'P0001', 'Negative value found on ''max_depth''', '26: Negative max_depth throws');
 SELECT throws_ok('depthFirstSearch27', 'P0001', 'Negative value found on ''max_depth''', '27: Negative max_depth throws');
 SELECT throws_ok('depthFirstSearch28', 'P0001', 'Negative value found on ''max_depth''', '28: Negative max_depth throws');
 SELECT throws_ok('depthFirstSearch29', 'P0001', 'Negative value found on ''max_depth''', '29: Negative max_depth throws');
 SELECT throws_ok('depthFirstSearch30', 'P0001', 'Negative value found on ''max_depth''', '30: Negative max_depth throws');
 SELECT throws_ok('depthFirstSearch31', 'P0001', 'Negative value found on ''max_depth''', '31: Negative max_depth throws');
+SELECT throws_ok('depthFirstSearch32', 'P0001', 'Negative value found on ''max_depth''', '32: Negative max_depth throws');
 
 
 
@@ -293,83 +293,83 @@ SELECT throws_ok('depthFirstSearch31', 'P0001', 'Negative value found on ''max_d
 
 -- 1 vertex tests
 
-PREPARE q32 AS
+PREPARE q33 AS
 SELECT id, source, 2 AS target, cost, reverse_cost
 FROM edge_table
 WHERE id = 2;
 
 -- Graph with only vertex 2
-SELECT set_eq('q32', $$VALUES (2, 2, 2, -1, 1)$$, 'q32: Graph with only vertex 2');
+SELECT set_eq('q33', $$VALUES (2, 2, 2, -1, 1)$$, 'q33: Graph with only vertex 2');
 
 -- 1 vertex tests (directed)
-
-PREPARE depthFirstSearch33 AS
-SELECT *
-FROM pgr_depthFirstSearch(
-    'q32',
-    2
-);
 
 PREPARE depthFirstSearch34 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
-    ARRAY[2]
+    'q33',
+    2
 );
 
 PREPARE depthFirstSearch35 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
-    2, max_depth => 2
+    'q33',
+    ARRAY[2]
 );
 
 PREPARE depthFirstSearch36 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
-    ARRAY[2], max_depth => 2
+    'q33',
+    2, max_depth => 2
 );
-
-SELECT set_eq('depthFirstSearch33', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '33: One row with node 2 is returned');
-SELECT set_eq('depthFirstSearch34', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '34: One row with node 2 is returned');
-SELECT set_eq('depthFirstSearch35', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '35: One row with node 2 is returned');
-SELECT set_eq('depthFirstSearch36', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '36: One row with node 2 is returned');
-
--- 1 vertex tests (undirected)
 
 PREPARE depthFirstSearch37 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
-    2, directed => false
+    'q33',
+    ARRAY[2], max_depth => 2
 );
+
+SELECT set_eq('depthFirstSearch34', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '34: One row with node 2 is returned');
+SELECT set_eq('depthFirstSearch35', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '35: One row with node 2 is returned');
+SELECT set_eq('depthFirstSearch36', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '36: One row with node 2 is returned');
+SELECT set_eq('depthFirstSearch37', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '37: One row with node 2 is returned');
+
+-- 1 vertex tests (undirected)
 
 PREPARE depthFirstSearch38 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
-    ARRAY[2], directed => false
+    'q33',
+    2, directed => false
 );
 
 PREPARE depthFirstSearch39 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
-    2, max_depth => 2, directed => false
+    'q33',
+    ARRAY[2], directed => false
 );
 
 PREPARE depthFirstSearch40 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q32',
+    'q33',
+    2, max_depth => 2, directed => false
+);
+
+PREPARE depthFirstSearch41 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q33',
     ARRAY[2], max_depth => 2, directed => false
 );
 
-SELECT set_eq('depthFirstSearch37', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '37: One row with node 2 is returned');
 SELECT set_eq('depthFirstSearch38', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '38: One row with node 2 is returned');
 SELECT set_eq('depthFirstSearch39', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '39: One row with node 2 is returned');
 SELECT set_eq('depthFirstSearch40', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '40: One row with node 2 is returned');
+SELECT set_eq('depthFirstSearch41', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '41: One row with node 2 is returned');
 
 
 
@@ -377,115 +377,115 @@ SELECT set_eq('depthFirstSearch40', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '40: One 
 
 -- 2 vertices tests
 
-PREPARE q41 AS
+PREPARE q42 AS
 SELECT id, source, target, cost, reverse_cost
 FROM edge_table
 WHERE id = 5;
 
 -- Graph with vertices 3 and 6 and edge from 3 to 6
-SELECT set_eq('q41', $$VALUES (5, 3, 6, 1, -1)$$, 'q41: Graph with two vertices 3 and 6 and edge from 3 to 6');
+SELECT set_eq('q42', $$VALUES (5, 3, 6, 1, -1)$$, 'q42: Graph with two vertices 3 and 6 and edge from 3 to 6');
 
 -- 2 vertices tests (directed)
-
-PREPARE depthFirstSearch42 AS
-SELECT *
-FROM pgr_depthFirstSearch(
-    'q41',
-    3
-);
 
 PREPARE depthFirstSearch43 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    ARRAY[3]
+    'q42',
+    3
 );
 
 PREPARE depthFirstSearch44 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    6
+    'q42',
+    ARRAY[3]
 );
 
 PREPARE depthFirstSearch45 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    ARRAY[6]
+    'q42',
+    6
 );
 
 PREPARE depthFirstSearch46 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    3, max_depth => 1
+    'q42',
+    ARRAY[6]
 );
 
 PREPARE depthFirstSearch47 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    3, max_depth => 0
+    'q42',
+    3, max_depth => 1
 );
-
-SELECT set_eq('depthFirstSearch42', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '42: Two rows are returned');
-SELECT set_eq('depthFirstSearch43', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '43: Two rows are returned');
-SELECT set_eq('depthFirstSearch44', $$VALUES (1, 0, 6, 6, -1, 0, 0)$$, '44: One row is returned');
-SELECT set_eq('depthFirstSearch45', $$VALUES (1, 0, 6, 6, -1, 0, 0)$$, '45: One row is returned');
-SELECT set_eq('depthFirstSearch46', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '46: Two rows are returned');
-SELECT set_eq('depthFirstSearch47', $$VALUES (1, 0, 3, 3, -1, 0, 0)$$, '47: One row is returned');
-
--- 2 vertices tests (undirected)
 
 PREPARE depthFirstSearch48 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    3, directed => false
+    'q42',
+    3, max_depth => 0
 );
+
+SELECT set_eq('depthFirstSearch43', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '43: Two rows are returned');
+SELECT set_eq('depthFirstSearch44', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '44: Two rows are returned');
+SELECT set_eq('depthFirstSearch45', $$VALUES (1, 0, 6, 6, -1, 0, 0)$$, '45: One row is returned');
+SELECT set_eq('depthFirstSearch46', $$VALUES (1, 0, 6, 6, -1, 0, 0)$$, '46: One row is returned');
+SELECT set_eq('depthFirstSearch47', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '47: Two rows are returned');
+SELECT set_eq('depthFirstSearch48', $$VALUES (1, 0, 3, 3, -1, 0, 0)$$, '48: One row is returned');
+
+-- 2 vertices tests (undirected)
 
 PREPARE depthFirstSearch49 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    ARRAY[3], directed => false
+    'q42',
+    3, directed => false
 );
 
 PREPARE depthFirstSearch50 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    6, directed => false
+    'q42',
+    ARRAY[3], directed => false
 );
 
 PREPARE depthFirstSearch51 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    ARRAY[6], directed => false
+    'q42',
+    6, directed => false
 );
 
 PREPARE depthFirstSearch52 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
-    3, max_depth => 1, directed => false
+    'q42',
+    ARRAY[6], directed => false
 );
 
 PREPARE depthFirstSearch53 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q41',
+    'q42',
+    3, max_depth => 1, directed => false
+);
+
+PREPARE depthFirstSearch54 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q42',
     3, max_depth => 0, directed => false
 );
 
-SELECT set_eq('depthFirstSearch48', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '48: Two rows are returned');
 SELECT set_eq('depthFirstSearch49', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '49: Two rows are returned');
-SELECT set_eq('depthFirstSearch50', $$VALUES (1, 0, 6, 6, -1, 0, 0), (2, 1, 6, 3, 5, 1, 1)$$, '50: Two rows are returned');
+SELECT set_eq('depthFirstSearch50', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '50: Two rows are returned');
 SELECT set_eq('depthFirstSearch51', $$VALUES (1, 0, 6, 6, -1, 0, 0), (2, 1, 6, 3, 5, 1, 1)$$, '51: Two rows are returned');
-SELECT set_eq('depthFirstSearch52', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '52: Two rows are returned');
-SELECT set_eq('depthFirstSearch53', $$VALUES (1, 0, 3, 3, -1, 0, 0)$$, '53: One row is returned');
+SELECT set_eq('depthFirstSearch52', $$VALUES (1, 0, 6, 6, -1, 0, 0), (2, 1, 6, 3, 5, 1, 1)$$, '52: Two rows are returned');
+SELECT set_eq('depthFirstSearch53', $$VALUES (1, 0, 3, 3, -1, 0, 0), (2, 1, 3, 6, 5, 1, 1)$$, '53: Two rows are returned');
+SELECT set_eq('depthFirstSearch54', $$VALUES (1, 0, 3, 3, -1, 0, 0)$$, '54: One row is returned');
 
 
 
@@ -506,71 +506,62 @@ INSERT INTO three_vertices_table (source, target, cost, reverse_cost) VALUES
     (3, 8, 10, -10),
     (6, 8, -1, 12);
 
-PREPARE q54 AS
+PREPARE q55 AS
 SELECT id, source, target, cost, reverse_cost
 FROM three_vertices_table;
 
 -- Cyclic Graph with three vertices 3, 6 and 8
-SELECT set_eq('q54',
+SELECT set_eq('q55',
     $$VALUES
         (1, 3, 6, 20, 15),
         (2, 3, 8, 10, -10),
         (3, 6, 8, -1, 12)
     $$,
-    'q54: Cyclic Graph with three vertices 3, 6 and 8'
+    'q55: Cyclic Graph with three vertices 3, 6 and 8'
 );
 
 -- 3 vertices tests (directed)
 
-PREPARE depthFirstSearch55 AS
-SELECT *
-FROM pgr_depthFirstSearch(
-    'q54',
-    3
-);
-
 PREPARE depthFirstSearch56 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q54',
-    6
+    'q55',
+    3
 );
 
 PREPARE depthFirstSearch57 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q54',
-    6, max_depth => 1
+    'q55',
+    6
 );
 
 PREPARE depthFirstSearch58 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q54',
-    2
+    'q55',
+    6, max_depth => 1
 );
 
 PREPARE depthFirstSearch59 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q54',
-    ARRAY[6, 3, 6]
+    'q55',
+    2
 );
 
-SELECT set_eq('depthFirstSearch55',
-    $$VALUES
-        (1, 0, 3, 3, -1, 0, 0),
-        (2, 1, 3, 6, 1, 20, 20),
-        (3, 1, 3, 8, 2, 10, 10)
-    $$,
-    '55: 3 vertices tests (directed)'
+PREPARE depthFirstSearch60 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q55',
+    ARRAY[6, 3, 6]
 );
 
 SELECT set_eq('depthFirstSearch56',
     $$VALUES
-        (1, 0, 6, 6, -1, 0, 0),
-        (2, 1, 6, 3, 1, 15, 15),
-        (3, 2, 6, 8, 2, 10, 25)
+        (1, 0, 3, 3, -1, 0, 0),
+        (2, 1, 3, 6, 1, 20, 20),
+        (3, 1, 3, 8, 2, 10, 10)
     $$,
     '56: 3 vertices tests (directed)'
 );
@@ -578,16 +569,25 @@ SELECT set_eq('depthFirstSearch56',
 SELECT set_eq('depthFirstSearch57',
     $$VALUES
         (1, 0, 6, 6, -1, 0, 0),
-        (2, 1, 6, 3, 1, 15, 15)
+        (2, 1, 6, 3, 1, 15, 15),
+        (3, 2, 6, 8, 2, 10, 25)
     $$,
     '57: 3 vertices tests (directed)'
 );
 
-SELECT is_empty('depthFirstSearch58',
-    '58: Vertex not present in graph -> Empty row is returned'
+SELECT set_eq('depthFirstSearch58',
+    $$VALUES
+        (1, 0, 6, 6, -1, 0, 0),
+        (2, 1, 6, 3, 1, 15, 15)
+    $$,
+    '58: 3 vertices tests (directed)'
 );
 
-SELECT set_eq('depthFirstSearch59',
+SELECT is_empty('depthFirstSearch59',
+    '59: Vertex not present in graph -> Empty row is returned'
+);
+
+SELECT set_eq('depthFirstSearch60',
     $$VALUES
         (1, 0, 3, 3, -1, 0, 0),
         (2, 1, 3, 6, 1, 20, 20),
@@ -596,46 +596,37 @@ SELECT set_eq('depthFirstSearch59',
         (5, 1, 6, 3, 1, 15, 15),
         (6, 2, 6, 8, 2, 10, 25)
     $$,
-    '59: 3 vertices tests (directed)'
+    '60: 3 vertices tests (directed)'
 );
 
 -- 3 vertices tests (undirected)
 
-PREPARE depthFirstSearch60 AS
-SELECT *
-FROM pgr_depthFirstSearch(
-    'q54',
-    3, directed => false
-);
-
 PREPARE depthFirstSearch61 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q54',
-    6, directed => false
+    'q55',
+    3, directed => false
 );
 
 PREPARE depthFirstSearch62 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q54',
-    6, max_depth => 1, directed => false
+    'q55',
+    6, directed => false
 );
 
-SELECT set_eq('depthFirstSearch60',
-    $$VALUES
-        (1, 0, 3, 3, -1, 0, 0),
-        (2, 1, 3, 6, 1, 20, 20),
-        (3, 2, 3, 8, 3, 12, 32)
-    $$,
-    '60: 3 vertices tests (undirected)'
+PREPARE depthFirstSearch63 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q55',
+    6, max_depth => 1, directed => false
 );
 
 SELECT set_eq('depthFirstSearch61',
     $$VALUES
-        (1, 0, 6, 6, -1, 0, 0),
-        (2, 1, 6, 3, 1, 20, 20),
-        (3, 2, 6, 8, 2, 10, 30)
+        (1, 0, 3, 3, -1, 0, 0),
+        (2, 1, 3, 6, 1, 20, 20),
+        (3, 2, 3, 8, 3, 12, 32)
     $$,
     '61: 3 vertices tests (undirected)'
 );
@@ -643,9 +634,18 @@ SELECT set_eq('depthFirstSearch61',
 SELECT set_eq('depthFirstSearch62',
     $$VALUES
         (1, 0, 6, 6, -1, 0, 0),
-        (2, 1, 6, 3, 1, 20, 20)
+        (2, 1, 6, 3, 1, 20, 20),
+        (3, 2, 6, 8, 2, 10, 30)
     $$,
     '62: 3 vertices tests (undirected)'
+);
+
+SELECT set_eq('depthFirstSearch63',
+    $$VALUES
+        (1, 0, 6, 6, -1, 0, 0),
+        (2, 1, 6, 3, 1, 20, 20)
+    $$,
+    '63: 3 vertices tests (undirected)'
 );
 
 
@@ -654,158 +654,158 @@ SELECT set_eq('depthFirstSearch62',
 
 -- 4 vertices tests
 
-PREPARE q63 AS
+PREPARE q64 AS
 SELECT id, source, target, cost, reverse_cost
 FROM edge_table
 WHERE (id >= 10 AND id <= 12)
     OR id = 8;
 
 -- Graph with vertices 5, 6, 10, 11
-SELECT set_eq('q63',
+SELECT set_eq('q64',
     $$VALUES
         (8, 5, 6, 1, 1),
         (10, 5, 10, 1, 1),
         (11, 6, 11, 1, -1),
         (12, 10, 11, 1, -1)
     $$,
-    '63: Graph with vertices 5, 6, 10 and 11'
+    '64: Graph with vertices 5, 6, 10 and 11'
 );
 
 -- 4 vertices tests (directed)
 
-PREPARE depthFirstSearch64 AS
-SELECT *
-FROM pgr_depthFirstSearch(
-    'q63',
-    5
-);
-
 PREPARE depthFirstSearch65 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q63',
-    6
+    'q64',
+    5
 );
 
 PREPARE depthFirstSearch66 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q63',
-    10
+    'q64',
+    6
 );
 
 PREPARE depthFirstSearch67 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q63',
+    'q64',
+    10
+);
+
+PREPARE depthFirstSearch68 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q64',
     11
 );
 
-SELECT set_eq('depthFirstSearch64',
+SELECT set_eq('depthFirstSearch65',
     $$VALUES
         (1, 0, 5, 5, -1, 0, 0),
         (2, 1, 5, 6, 8, 1, 1),
         (3, 2, 5, 11, 11, 1, 2),
         (4, 1, 5, 10, 10, 1, 1)
     $$,
-    '64: 4 vertices tests (directed)'
-);
-
-SELECT set_eq('depthFirstSearch65',
-    $$VALUES
-        (1, 0, 6, 6, -1, 0, 0),
-        (2, 1, 6, 5, 8, 1, 1),
-        (3, 2, 6, 10, 10, 1, 2),
-        (4, 3, 6, 11, 12, 1, 3)
-    $$,
     '65: 4 vertices tests (directed)'
 );
 
 SELECT set_eq('depthFirstSearch66',
     $$VALUES
-        (1, 0, 10, 10, -1, 0, 0),
-        (2, 1, 10, 5, 10, 1, 1),
-        (3, 2, 10, 6, 8, 1, 2),
-        (4, 3, 10, 11, 11, 1, 3)
+        (1, 0, 6, 6, -1, 0, 0),
+        (2, 1, 6, 5, 8, 1, 1),
+        (3, 2, 6, 10, 10, 1, 2),
+        (4, 3, 6, 11, 12, 1, 3)
     $$,
     '66: 4 vertices tests (directed)'
 );
 
 SELECT set_eq('depthFirstSearch67',
     $$VALUES
-        (1, 0, 11, 11, -1, 0, 0)
+        (1, 0, 10, 10, -1, 0, 0),
+        (2, 1, 10, 5, 10, 1, 1),
+        (3, 2, 10, 6, 8, 1, 2),
+        (4, 3, 10, 11, 11, 1, 3)
     $$,
     '67: 4 vertices tests (directed)'
 );
 
--- 4 vertices tests (undirected)
-
-PREPARE depthFirstSearch68 AS
-SELECT *
-FROM pgr_depthFirstSearch(
-    'q63',
-    5, directed => false
+SELECT set_eq('depthFirstSearch68',
+    $$VALUES
+        (1, 0, 11, 11, -1, 0, 0)
+    $$,
+    '68: 4 vertices tests (directed)'
 );
+
+-- 4 vertices tests (undirected)
 
 PREPARE depthFirstSearch69 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q63',
-    6, directed => false
+    'q64',
+    5, directed => false
 );
 
 PREPARE depthFirstSearch70 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q63',
-    10, directed => false
+    'q64',
+    6, directed => false
 );
 
 PREPARE depthFirstSearch71 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'q63',
+    'q64',
+    10, directed => false
+);
+
+PREPARE depthFirstSearch72 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q64',
     11, directed => false
 );
 
-SELECT set_eq('depthFirstSearch68',
+SELECT set_eq('depthFirstSearch69',
     $$VALUES
         (1, 0, 5, 5, -1, 0, 0),
         (2, 1, 5, 6, 8, 1, 1),
         (3, 2, 5, 11, 11, 1, 2),
         (4, 3, 5, 10, 12, 1, 3)
     $$,
-    '68: 4 vertices tests (undirected)'
+    '69: 4 vertices tests (undirected)'
 );
 
-SELECT set_eq('depthFirstSearch69',
+SELECT set_eq('depthFirstSearch70',
     $$VALUES
         (1, 0, 6, 6, -1, 0, 0),
         (2, 1, 6, 5, 8, 1, 1),
         (3, 2, 6, 10, 10, 1, 2),
         (4, 3, 6, 11, 12, 1, 3)
     $$,
-    '69: 4 vertices tests (undirected)'
+    '70: 4 vertices tests (undirected)'
 );
 
-SELECT set_eq('depthFirstSearch70',
+SELECT set_eq('depthFirstSearch71',
     $$VALUES
         (1, 0, 10, 10, -1, 0, 0),
         (2, 1, 10, 5, 10, 1, 1),
         (3, 2, 10, 6, 8, 1, 2),
         (4, 3, 10, 11, 11, 1, 3)
     $$,
-    '70: 4 vertices tests (undirected)'
+    '71: 4 vertices tests (undirected)'
 );
 
-SELECT set_eq('depthFirstSearch71',
+SELECT set_eq('depthFirstSearch72',
     $$VALUES
         (1, 0, 11, 11, -1, 0, 0),
         (2, 1, 11, 6, 11, 1, 1),
         (3, 2, 11, 5, 8, 1, 2),
         (4, 3, 11, 10, 10, 1, 3)
     $$,
-    '71: 4 vertices tests (undirected)'
+    '72: 4 vertices tests (undirected)'
 );
 
 

--- a/pgtap/depthFirstSearch/depthFirstSearch-edge-cases.sql
+++ b/pgtap/depthFirstSearch/depthFirstSearch-edge-cases.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(71);
+SELECT plan(72);
 
 
 
@@ -19,54 +19,42 @@ SELECT is_empty('q1', 'q1: Graph with 0 edge and 0 vertex');
 PREPARE depthFirstSearch2 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     5
 );
 
 PREPARE depthFirstSearch3 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[5]
 );
 
 PREPARE depthFirstSearch4 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[2, 5]
 );
 
 PREPARE depthFirstSearch5 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     5, max_depth => 2
 );
 
 PREPARE depthFirstSearch6 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[5], max_depth => 2
 );
 
 PREPARE depthFirstSearch7 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[2, 5], max_depth => 2
 );
 
@@ -82,54 +70,42 @@ SELECT is_empty('depthFirstSearch7', '7: Graph with 0 edge and 0 vertex -> Empty
 PREPARE depthFirstSearch8 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     5, directed => false
 );
 
 PREPARE depthFirstSearch9 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[5], directed => false
 );
 
 PREPARE depthFirstSearch10 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[2, 5], directed => false
 );
 
 PREPARE depthFirstSearch11 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     5, max_depth => 2, directed => false
 );
 
 PREPARE depthFirstSearch12 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[5], max_depth => 2, directed => false
 );
 
 PREPARE depthFirstSearch13 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id > 18',
+    'q1',
     ARRAY[2, 5], max_depth => 2, directed => false
 );
 
@@ -144,53 +120,56 @@ SELECT is_empty('depthFirstSearch13', '13: Graph with 0 edge and 0 vertex -> Emp
 
 
 
+-- vertex not present in graph tests
+
+PREPARE q14 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table;
+
+-- pgRouting Sample Data
+SELECT isnt_empty('q14', 'q14: pgRouting Sample Data');
+
 -- vertex not present in graph tests (directed)
 
 PREPARE depthFirstSearch14 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     -10
 );
 
 PREPARE depthFirstSearch15 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[-10]
 );
 
 PREPARE depthFirstSearch16 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[20, -10]
 );
 
 PREPARE depthFirstSearch17 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     -10, max_depth => 2
 );
 
 PREPARE depthFirstSearch18 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[-10], max_depth => 2
 );
 
 PREPARE depthFirstSearch19 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[20, -10], max_depth => 2
 );
 
@@ -206,48 +185,42 @@ SELECT is_empty('depthFirstSearch19', '19: Vertex not present in graph -> Empty 
 PREPARE depthFirstSearch20 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     -10, directed => false
 );
 
 PREPARE depthFirstSearch21 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[-10], directed => false
 );
 
 PREPARE depthFirstSearch22 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[20, -10], directed => false
 );
 
 PREPARE depthFirstSearch23 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     -10, max_depth => 2, directed => false
 );
 
 PREPARE depthFirstSearch24 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[-10], max_depth => 2, directed => false
 );
 
 PREPARE depthFirstSearch25 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[20, -10], max_depth => 2, directed => false
 );
 
@@ -268,48 +241,42 @@ SELECT is_empty('depthFirstSearch25', '25: Vertex not present in graph -> Empty 
 PREPARE depthFirstSearch26 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     4, max_depth => -3
 );
 
 PREPARE depthFirstSearch27 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[4], max_depth => -3
 );
 
 PREPARE depthFirstSearch28 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[4, 20], max_depth => -3
 );
 
 PREPARE depthFirstSearch29 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     4, max_depth => -3, directed => false
 );
 
 PREPARE depthFirstSearch30 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[4], max_depth => -3, directed => false
 );
 
 PREPARE depthFirstSearch31 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table',
+    'q14',
     ARRAY[4, 20], max_depth => -3, directed => false
 );
 
@@ -339,36 +306,28 @@ SELECT set_eq('q32', $$VALUES (2, 2, 2, -1, 1)$$, 'q32: Graph with only vertex 2
 PREPARE depthFirstSearch33 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     2
 );
 
 PREPARE depthFirstSearch34 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     ARRAY[2]
 );
 
 PREPARE depthFirstSearch35 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     2, max_depth => 2
 );
 
 PREPARE depthFirstSearch36 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     ARRAY[2], max_depth => 2
 );
 
@@ -382,36 +341,28 @@ SELECT set_eq('depthFirstSearch36', $$VALUES (1, 0, 2, 2, -1, 0, 0)$$, '36: One 
 PREPARE depthFirstSearch37 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     2, directed => false
 );
 
 PREPARE depthFirstSearch38 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     ARRAY[2], directed => false
 );
 
 PREPARE depthFirstSearch39 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     2, max_depth => 2, directed => false
 );
 
 PREPARE depthFirstSearch40 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, 2 AS target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 2',
+    'q32',
     ARRAY[2], max_depth => 2, directed => false
 );
 
@@ -439,54 +390,42 @@ SELECT set_eq('q41', $$VALUES (5, 3, 6, 1, -1)$$, 'q41: Graph with two vertices 
 PREPARE depthFirstSearch42 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     3
 );
 
 PREPARE depthFirstSearch43 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     ARRAY[3]
 );
 
 PREPARE depthFirstSearch44 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     6
 );
 
 PREPARE depthFirstSearch45 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     ARRAY[6]
 );
 
 PREPARE depthFirstSearch46 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     3, max_depth => 1
 );
 
 PREPARE depthFirstSearch47 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     3, max_depth => 0
 );
 
@@ -502,54 +441,42 @@ SELECT set_eq('depthFirstSearch47', $$VALUES (1, 0, 3, 3, -1, 0, 0)$$, '47: One 
 PREPARE depthFirstSearch48 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     3, directed => false
 );
 
 PREPARE depthFirstSearch49 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     ARRAY[3], directed => false
 );
 
 PREPARE depthFirstSearch50 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     6, directed => false
 );
 
 PREPARE depthFirstSearch51 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     ARRAY[6], directed => false
 );
 
 PREPARE depthFirstSearch52 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     3, max_depth => 1, directed => false
 );
 
 PREPARE depthFirstSearch53 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE id = 5',
+    'q41',
     3, max_depth => 0, directed => false
 );
 
@@ -598,40 +525,35 @@ SELECT set_eq('q54',
 PREPARE depthFirstSearch55 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     3
 );
 
 PREPARE depthFirstSearch56 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     6
 );
 
 PREPARE depthFirstSearch57 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     6, max_depth => 1
 );
 
 PREPARE depthFirstSearch58 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     2
 );
 
 PREPARE depthFirstSearch59 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     ARRAY[6, 3, 6]
 );
 
@@ -682,24 +604,21 @@ SELECT set_eq('depthFirstSearch59',
 PREPARE depthFirstSearch60 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     3, directed => false
 );
 
 PREPARE depthFirstSearch61 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     6, directed => false
 );
 
 PREPARE depthFirstSearch62 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM three_vertices_table',
+    'q54',
     6, max_depth => 1, directed => false
 );
 
@@ -757,40 +676,28 @@ SELECT set_eq('q63',
 PREPARE depthFirstSearch64 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     5
 );
 
 PREPARE depthFirstSearch65 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     6
 );
 
 PREPARE depthFirstSearch66 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     10
 );
 
 PREPARE depthFirstSearch67 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     11
 );
 
@@ -836,40 +743,28 @@ SELECT set_eq('depthFirstSearch67',
 PREPARE depthFirstSearch68 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     5, directed => false
 );
 
 PREPARE depthFirstSearch69 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     6, directed => false
 );
 
 PREPARE depthFirstSearch70 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     10, directed => false
 );
 
 PREPARE depthFirstSearch71 AS
 SELECT *
 FROM pgr_depthFirstSearch(
-    'SELECT id, source, target, cost, reverse_cost
-    FROM edge_table
-    WHERE (id >= 10 AND id <= 12)
-        OR id = 8',
+    'q63',
     11, directed => false
 );
 

--- a/pgtap/depthFirstSearch/depthFirstSearch-rows-check.sql
+++ b/pgtap/depthFirstSearch/depthFirstSearch-rows-check.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(5);
+SELECT plan(1);
 
 
 -- Check whether the same set of rows are returned always
@@ -15,33 +15,22 @@ SELECT id, source, target, cost, reverse_cost
 FROM edge_table
 ORDER BY id DESC;
 
-SELECT SETSEED(1);
 
-PREPARE q3 AS
-SELECT id, source, target, cost, reverse_cost
-FROM edge_table
-ORDER BY RANDOM();
+PREPARE depthFirstSearch1 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q1',
+    1
+);
 
-PREPARE q4 AS
-SELECT id, source, target, cost, reverse_cost
-FROM edge_table
-ORDER BY RANDOM();
+PREPARE depthFirstSearch2 AS
+SELECT *
+FROM pgr_depthFirstSearch(
+    'q2',
+    1
+);
 
-PREPARE q5 AS
-SELECT id, source, target, cost, reverse_cost
-FROM edge_table
-ORDER BY RANDOM();
-
-PREPARE q6 AS
-SELECT id, source, target, cost, reverse_cost
-FROM edge_table
-ORDER BY RANDOM();
-
-SELECT set_eq('q1', 'q2', '1: Should return same set of rows');
-SELECT set_eq('q1', 'q3', '2: Should return same set of rows');
-SELECT set_eq('q1', 'q4', '3: Should return same set of rows');
-SELECT set_eq('q1', 'q5', '4: Should return same set of rows');
-SELECT set_eq('q1', 'q6', '5: Should return same set of rows');
+SELECT set_eq('depthFirstSearch1', 'depthFirstSearch2', '1: Should return same set of rows');
 
 
 SELECT * FROM finish();

--- a/pgtap/depthFirstSearch/depthFirstSearch-rows-check.sql
+++ b/pgtap/depthFirstSearch/depthFirstSearch-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(5);
+
+
+-- Check whether the same set of rows are returned always
+
+PREPARE q1 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY id;
+
+PREPARE q2 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY id DESC;
+
+SELECT SETSEED(1);
+
+PREPARE q3 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY RANDOM();
+
+PREPARE q4 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY RANDOM();
+
+PREPARE q5 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY RANDOM();
+
+PREPARE q6 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY RANDOM();
+
+SELECT set_eq('q1', 'q2', '1: Should return same set of rows');
+SELECT set_eq('q1', 'q3', '2: Should return same set of rows');
+SELECT set_eq('q1', 'q4', '3: Should return same set of rows');
+SELECT set_eq('q1', 'q5', '4: Should return same set of rows');
+SELECT set_eq('q1', 'q6', '5: Should return same set of rows');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
+++ b/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
@@ -1,0 +1,12 @@
+\i setup.sql
+
+SELECT plan(1);
+
+SELECT todo_start('Complete the no crash tests');
+
+SELECT pass( 'A sample test' );
+
+SELECT todo_end();
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
+++ b/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(3);
+SELECT plan(7);
 
 SELECT todo_start('Complete the no crash tests');
 
@@ -17,7 +17,31 @@ SELECT isnt_empty('edges', 'Should be not empty to tests be meaningful');
 SELECT is_empty('null_ret', 'Should be empty to tests be meaningful');
 SELECT set_eq('null_ret_arr', 'SELECT NULL::BIGINT[]', 'Should be empty to tests be meaningful');
 
+
+CREATE OR REPLACE FUNCTION test_function()
+RETURNS SETOF TEXT AS
+$BODY$
+DECLARE
+params TEXT[];
+subs TEXT[];
+BEGIN
+    -- sequentialVertexColoring
+    params = ARRAY[
+    '$$SELECT id, source, target, cost, reverse_cost  FROM edge_table$$'
+    ]::TEXT[];
+    subs = ARRAY[
+    'NULL'
+    ]::TEXT[];
+
+    RETURN query SELECT * FROM no_crash_test('pgr_sequentialVertexColoring', params, subs);
+
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+
+SELECT * FROM test_function();
+
 SELECT todo_end();
 
-SELECT * FROM finish();
 ROLLBACK;

--- a/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
+++ b/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
@@ -1,10 +1,21 @@
 \i setup.sql
 
-SELECT plan(1);
+SELECT plan(3);
 
 SELECT todo_start('Complete the no crash tests');
 
-SELECT pass( 'A sample test' );
+PREPARE edges AS
+SELECT id, source, target, cost, reverse_cost  FROM edge_table;
+
+PREPARE null_ret AS
+SELECT id FROM edge_table_vertices_pgr  WHERE id IN (-1);
+
+PREPARE null_ret_arr AS
+SELECT array_agg(id) FROM edge_table_vertices_pgr  WHERE id IN (-1);
+
+SELECT isnt_empty('edges', 'Should be not empty to tests be meaningful');
+SELECT is_empty('null_ret', 'Should be empty to tests be meaningful');
+SELECT set_eq('null_ret_arr', 'SELECT NULL::BIGINT[]', 'Should be empty to tests be meaningful');
 
 SELECT todo_end();
 

--- a/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
+++ b/pgtap/graphColoring/no_crash_test-sequentialVertexColoring.sql
@@ -2,8 +2,6 @@
 
 SELECT plan(7);
 
-SELECT todo_start('Complete the no crash tests');
-
 PREPARE edges AS
 SELECT id, source, target, cost, reverse_cost  FROM edge_table;
 
@@ -41,7 +39,5 @@ LANGUAGE plpgsql VOLATILE;
 
 
 SELECT * FROM test_function();
-
-SELECT todo_end();
 
 ROLLBACK;

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(8);
+SELECT plan(10);
 
 -- 0 edge, 0 vertex test
 
@@ -83,6 +83,24 @@ FROM pgr_sequentialVertexColoring(
 );
 
 SELECT set_eq('sequentialVertexColoring8', $$VALUES (1, 0), (2, 0)$$, '8: Both vertices have same color');
+
+
+-- 3 vertices test
+
+PREPARE q9 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+WHERE id <= 2;
+
+SELECT set_eq('q9', $$VALUES (1, 1, 2, 1, 1), (2, 2, 3, -1, 1)$$, 'q9: Graph with three vertices 1, 2 and 3');
+
+PREPARE sequentialVertexColoring10 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q9'
+);
+
+SELECT set_eq('sequentialVertexColoring10', $$VALUES (1, 0), (2, 1), (3, 0)$$, '10: 2 colors are required');
 
 
 SELECT * FROM finish();

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,12 +1,27 @@
 \i setup.sql
 
-SELECT plan(1);
+SELECT plan(2);
 
-SELECT todo_start('Complete the edge cases (unit tests)');
+-- 0 edge, 0 vertex tests
 
-SELECT pass( 'A sample test' );
+PREPARE q1 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+WHERE id > 18;
 
-SELECT todo_end();
+-- Graph is empty - it has 0 edge and 0 vertex
+SELECT is_empty('q1', 'q1: Graph with 0 edge and 0 vertex');
+
+-- 0 edge, 0 vertex tests (directed)
+
+PREPARE sequentialVertexColoring2 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q1'
+);
+
+SELECT is_empty('sequentialVertexColoring2', '2: Graph with 0 edge and 0 vertex -> Empty row is returned');
+
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,8 +1,8 @@
 \i setup.sql
 
-SELECT plan(4);
+SELECT plan(6);
 
--- 0 edge, 0 vertex tests
+-- 0 edge, 0 vertex test
 
 PREPARE q1 AS
 SELECT id, source, target, cost, reverse_cost
@@ -20,7 +20,7 @@ FROM pgr_sequentialVertexColoring(
 SELECT is_empty('sequentialVertexColoring2', '2: Graph with 0 edge and 0 vertex -> Empty row is returned');
 
 
--- 1 vertex tests
+-- 1 vertex test
 
 PREPARE q3 AS
 SELECT id, source, 2 AS target, cost, reverse_cost
@@ -36,6 +36,24 @@ FROM pgr_sequentialVertexColoring(
 );
 
 SELECT set_eq('sequentialVertexColoring4', $$VALUES (2, 0)$$, '4: Node 2 with color 0 is returned');
+
+
+-- 2 vertices test
+
+PREPARE q5 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+WHERE id = 5;
+
+SELECT set_eq('q5', $$VALUES (5, 3, 6, 1, -1)$$, 'q5: Graph with two vertices 3 and 6 and edge from 3 to 6');
+
+PREPARE sequentialVertexColoring6 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q5'
+);
+
+SELECT set_eq('sequentialVertexColoring6', $$VALUES (3, 0), (6, 1)$$, '6: Both vertices have different color');
 
 
 SELECT * FROM finish();

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,0 +1,12 @@
+\i setup.sql
+
+SELECT plan(1);
+
+SELECT todo_start('Complete the edge cases (unit tests)');
+
+SELECT pass( 'A sample test' );
+
+SELECT todo_end();
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(10);
+SELECT plan(12);
 
 -- 0 edge, 0 vertex test
 
@@ -100,8 +100,44 @@ FROM pgr_sequentialVertexColoring(
     'q9'
 );
 
-SELECT set_eq('sequentialVertexColoring10', $$VALUES (1, 0), (2, 1), (3, 0)$$, '10: 2 colors are required');
+SELECT set_eq('sequentialVertexColoring10', $$VALUES (1, 0), (2, 1), (3, 0)$$, '10: Two colors are required');
 
+
+-- 3 vertices tests (cyclic)
+
+CREATE TABLE three_vertices_table (
+    id BIGSERIAL,
+    source BIGINT,
+    target BIGINT,
+    cost FLOAT,
+    reverse_cost FLOAT
+);
+
+INSERT INTO three_vertices_table (source, target, cost, reverse_cost) VALUES
+    (3, 6, 20, 15),
+    (3, 8, 10, -10),
+    (6, 8, -1, 12);
+
+PREPARE q11 AS
+SELECT id, source, target, cost, reverse_cost
+FROM three_vertices_table;
+
+SELECT set_eq('q11',
+    $$VALUES
+        (1, 3, 6, 20, 15),
+        (2, 3, 8, 10, -10),
+        (3, 6, 8, -1, 12)
+    $$,
+    'q11: Cyclic Graph with three vertices 3, 6 and 8'
+);
+
+PREPARE sequentialVertexColoring12 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q11'
+);
+
+SELECT set_eq('sequentialVertexColoring12', $$VALUES (3, 0), (6, 1), (8, 2)$$, '12: Three colors are required');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(6);
+SELECT plan(8);
 
 -- 0 edge, 0 vertex test
 
@@ -38,14 +38,14 @@ FROM pgr_sequentialVertexColoring(
 SELECT set_eq('sequentialVertexColoring4', $$VALUES (2, 0)$$, '4: Node 2 with color 0 is returned');
 
 
--- 2 vertices test
+-- 2 vertices test (connected)
 
 PREPARE q5 AS
 SELECT id, source, target, cost, reverse_cost
 FROM edge_table
-WHERE id = 5;
+WHERE id = 7;
 
-SELECT set_eq('q5', $$VALUES (5, 3, 6, 1, -1)$$, 'q5: Graph with two vertices 3 and 6 and edge from 3 to 6');
+SELECT set_eq('q5', $$VALUES (7, 8, 5, 1, 1)$$, 'q5: Graph with two connected vertices 8 and 5');
 
 PREPARE sequentialVertexColoring6 AS
 SELECT *
@@ -53,7 +53,36 @@ FROM pgr_sequentialVertexColoring(
     'q5'
 );
 
-SELECT set_eq('sequentialVertexColoring6', $$VALUES (3, 0), (6, 1)$$, '6: Both vertices have different color');
+SELECT set_eq('sequentialVertexColoring6', $$VALUES (5, 1), (8, 0)$$, '6: Both vertices have different color');
+
+
+-- 2 vertices test (isolated)
+
+CREATE TABLE two_isolated_vertices_table (
+    id BIGSERIAL,
+    source BIGINT,
+    target BIGINT,
+    cost FLOAT,
+    reverse_cost FLOAT
+);
+
+INSERT INTO two_isolated_vertices_table (source, target, cost, reverse_cost) VALUES
+    (2, 2, -1, 1),
+    (1, 1, 1, -1);
+
+PREPARE q7 AS
+SELECT id, source, target, cost, reverse_cost
+FROM two_isolated_vertices_table;
+
+SELECT set_eq('q7', $$VALUES (1, 2, 2, -1, 1), (2, 1, 1, 1, -1)$$, 'q7: Graph with two isolated vertices 1 and 2');
+
+PREPARE sequentialVertexColoring8 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q7'
+);
+
+SELECT set_eq('sequentialVertexColoring8', $$VALUES (1, 0), (2, 0)$$, '8: Both vertices have same color');
 
 
 SELECT * FROM finish();

--- a/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-edge-cases.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(2);
+SELECT plan(4);
 
 -- 0 edge, 0 vertex tests
 
@@ -9,10 +9,7 @@ SELECT id, source, target, cost, reverse_cost
 FROM edge_table
 WHERE id > 18;
 
--- Graph is empty - it has 0 edge and 0 vertex
 SELECT is_empty('q1', 'q1: Graph with 0 edge and 0 vertex');
-
--- 0 edge, 0 vertex tests (directed)
 
 PREPARE sequentialVertexColoring2 AS
 SELECT *
@@ -21,6 +18,24 @@ FROM pgr_sequentialVertexColoring(
 );
 
 SELECT is_empty('sequentialVertexColoring2', '2: Graph with 0 edge and 0 vertex -> Empty row is returned');
+
+
+-- 1 vertex tests
+
+PREPARE q3 AS
+SELECT id, source, 2 AS target, cost, reverse_cost
+FROM edge_table
+WHERE id = 2;
+
+SELECT set_eq('q3', $$VALUES (2, 2, 2, -1, 1)$$, 'q3: Graph with only vertex 2');
+
+PREPARE sequentialVertexColoring4 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q3'
+);
+
+SELECT set_eq('sequentialVertexColoring4', $$VALUES (2, 0)$$, '4: Node 2 with color 0 is returned');
 
 
 SELECT * FROM finish();

--- a/pgtap/graphColoring/sequentialVertexColoring-innerQuery.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-innerQuery.sql
@@ -2,11 +2,7 @@
 
 SELECT plan(54);
 
-SELECT todo_start('Complete the inner query tests');
-
 SELECT style_dijkstra('pgr_sequentialVertexColoring', ')');
-
-SELECT todo_end();
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/pgtap/graphColoring/sequentialVertexColoring-innerQuery.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-innerQuery.sql
@@ -1,10 +1,10 @@
 \i setup.sql
 
-SELECT plan(1);
+SELECT plan(54);
 
 SELECT todo_start('Complete the inner query tests');
 
-SELECT pass( 'A sample test' );
+SELECT style_dijkstra('pgr_sequentialVertexColoring', ')');
 
 SELECT todo_end();
 

--- a/pgtap/graphColoring/sequentialVertexColoring-rows-check.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-rows-check.sql
@@ -1,0 +1,35 @@
+\i setup.sql
+
+SELECT plan(1);
+
+
+-- Check whether the same set of rows are returned always
+
+PREPARE q1 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY id;
+
+PREPARE q2 AS
+SELECT id, source, target, cost, reverse_cost
+FROM edge_table
+ORDER BY id DESC;
+
+
+PREPARE sequentialVertexColoring1 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q1'
+);
+
+PREPARE sequentialVertexColoring2 AS
+SELECT *
+FROM pgr_sequentialVertexColoring(
+    'q2'
+);
+
+SELECT set_eq('sequentialVertexColoring1', 'sequentialVertexColoring2', '1: Should return same set of rows');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(3);
+SELECT plan(4);
 
 SELECT todo_start('Complete the types check');
 
@@ -8,6 +8,14 @@ SELECT has_function('pgr_sequentialvertexcoloring');
 
 SELECT has_function('pgr_sequentialvertexcoloring', ARRAY['text']);
 SELECT function_returns('pgr_sequentialvertexcoloring', ARRAY['text'],  'setof record');
+
+-- pgr_sequentialvertexcoloring
+-- parameter names
+SELECT bag_has(
+    $$SELECT  proargnames from pg_proc where proname = 'pgr_sequentialvertexcoloring'$$,
+    $$SELECT  '{"","node","color"}'::TEXT[] $$
+);
+
 
 SELECT todo_end();
 

--- a/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
@@ -1,6 +1,6 @@
 \i setup.sql
 
-SELECT plan(4);
+SELECT plan(5);
 
 SELECT todo_start('Complete the types check');
 
@@ -16,6 +16,13 @@ SELECT bag_has(
     $$SELECT  '{"","node","color"}'::TEXT[] $$
 );
 
+-- parameter types
+SELECT set_eq(
+    $$SELECT  proallargtypes from pg_proc where proname = 'pgr_sequentialvertexcoloring'$$,
+    $$VALUES
+        ('{25,20,20}'::OID[])
+    $$
+);
 
 SELECT todo_end();
 

--- a/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
@@ -1,10 +1,13 @@
 \i setup.sql
 
-SELECT plan(1);
+SELECT plan(3);
 
 SELECT todo_start('Complete the types check');
 
-SELECT pass( 'A sample test' );
+SELECT has_function('pgr_sequentialvertexcoloring');
+
+SELECT has_function('pgr_sequentialvertexcoloring', ARRAY['text']);
+SELECT function_returns('pgr_sequentialvertexcoloring', ARRAY['text'],  'setof record');
 
 SELECT todo_end();
 

--- a/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
+++ b/pgtap/graphColoring/sequentialVertexColoring-typesCheck.sql
@@ -2,8 +2,6 @@
 
 SELECT plan(5);
 
-SELECT todo_start('Complete the types check');
-
 SELECT has_function('pgr_sequentialvertexcoloring');
 
 SELECT has_function('pgr_sequentialvertexcoloring', ARRAY['text']);
@@ -23,8 +21,6 @@ SELECT set_eq(
         ('{25,20,20}'::OID[])
     $$
 );
-
-SELECT todo_end();
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
- [x] Added pgTAP test - server no-crash-test for null parameters - `no_crash_test-sequentialVertexColoring.sql`.
- [x] Added pgTAP test - parameter types check - `sequentialVertexColoring-types-check.sql`.
- [x] Added pgTAP test - inner query test - `sequentialVertexColoring-innerQuery.sql`.
- [x] Added prepared statement in the queries and tested all prepared statements - `depthFirstSearch-edge-cases.sql`.
- [x] Added test to check whether the same set of rows are returned always - `depthFirstSearch-rows-check.sql`.
- [x] Added pgTAP unit tests for different small graphs: (`sequentialVertexColoring-edge-cases.sql`)
  - [x] empty graph
  - [x] one vertex graph
  - [x] two vertices graph
  - [x] three vertices graph
  - [x] four vertices graph
- [x] Added test to check whether the same set of rows are returned always - `sequentialVertexColoring-rows-check.sql`.
- [x] Refactored the code (if required), to meet the pgRouting guidelines and Google C++ Style Guide.
- [x] The second function `pgr_sequentialVertexColoring` with all the tests and documentation is complete.
- [x] Made all the required changes in both the functions - `depthFirstSearch` and `sequentialVertexColoring` according to the mentor's reviews.