### PR TITLE
Closes #69 adds allpairs pgtap tests to check output after rows ordering

### DIFF
--- a/pgtap/allpairs/floydWarshall-rows-check.sql
+++ b/pgtap/allpairs/floydWarshall-rows-check.sql
@@ -1,0 +1,81 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutputDirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id'
+);
+
+PREPARE descendingOrderDirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrderDirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()'
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/allpairs/johnson-rows-check.sql
+++ b/pgtap/allpairs/johnson-rows-check.sql
@@ -1,0 +1,81 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutputDirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id'
+);
+
+PREPARE descendingOrderDirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrderDirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()'
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Fixes #69.

Changes proposed in this pull request:
- Adds pgTAP tests for allpairs that check the output after rows ordering.

@pgRouting/admins
