### PR TITLE
Closes #75 adds chinese postman pgtap tests to check output after row ordering

### DIFF
--- a/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
+++ b/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
@@ -1,0 +1,40 @@
+\i setup.sql
+
+SELECT plan(5);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_chinesePostman(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    WHERE id < 17
+    ORDER BY id'
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_chinesePostman(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    WHERE id < 17
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_chinesePostman(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    WHERE id < 17
+    ORDER BY RANDOM()'
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
+++ b/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
@@ -30,7 +30,7 @@ SELECT * FROM pgr_chinesePostman(
     ORDER BY RANDOM()'
 );
 
-SELECT todo_start('Fix the code to return same set of rows');
+SELECT todo_start('Chinese Postman Problem is Experimental, tests left pending');
 
 SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
 SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');

--- a/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
+++ b/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
@@ -30,11 +30,15 @@ SELECT * FROM pgr_chinesePostman(
     ORDER BY RANDOM()'
 );
 
+SELECT todo_start('Fix the code to return same set of rows');
+
 SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
 SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
 SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
 SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
 SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+SELECT todo_end();
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/pgtap/chinese/chinesePostmanCost/chinesePostmanCost-rows-check.sql
+++ b/pgtap/chinese/chinesePostmanCost/chinesePostmanCost-rows-check.sql
@@ -1,0 +1,40 @@
+\i setup.sql
+
+SELECT plan(5);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_chinesePostmanCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    WHERE id < 17
+    ORDER BY id'
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_chinesePostmanCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    WHERE id < 17
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_chinesePostmanCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    WHERE id < 17
+    ORDER BY RANDOM()'
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Fixes #75 

Changes proposed in this pull request:
- Adds pgTAP tests for chinese postman that check the output after rows ordering.

@pgRouting/admins
