### PR TITLE
Fixing grammar in pgTAP tests & Added documentation (ordering issue)

### DIFF
--- a/include/cpp_common/pgr_base_graph.hpp
+++ b/include/cpp_common/pgr_base_graph.hpp
@@ -427,15 +427,16 @@ class Pgr_base_graph {
              graph_add_neg_edge(edge, normal);
          }
      }
+     //@}
 
      //! @name Insert edges sorted
      //@{
      /*! @brief Inserts *count* edges of type *T* into the graph in sorted order,
       *
       *  Converts the edges to a std::vector<T> & calls the overloaded
-      *  twin function, which sorts the edges in an increasing order of
-      *  their id, then source (if ids are equal) and then target
-      *  (if ids and sources are equal).
+      *  twin function, which calls the function to sort the edges
+      *  in an increasing order of their id, then source (if ids are equal)
+      *  and then target (if ids and sources are equal).
       *
       *  @param edges
       *  @param count
@@ -445,6 +446,16 @@ class Pgr_base_graph {
          insert_edges_sorted(std::vector < T >(edges, edges + count));
      }
 
+     /*! @brief Sorts edges of the graph, passed in the form of C array
+      *
+      *  First, it sorts the edges in the increasing order of the target vertices,
+      *  then it does a stable sort in an increasing order of the source vertices.
+      *  Finally, it does a stable sort in an increasing order of the id of edges.
+      *  Hence, the edges get sorted in the order of id, then source, then target.
+      *
+      *  @param edges
+      *  @param count
+      */
      template < typename T>
          void sort_edges(T *&edges, int64_t count) {
              std::sort(edges, edges + count,
@@ -461,6 +472,15 @@ class Pgr_base_graph {
                  });
          }
 
+     /*! @brief Sorts edges of the graph, passed in the form of C++ container - vector
+      *
+      *  First, it sorts the edges in the increasing order of the target vertices,
+      *  then it does a stable sort in an increasing order of the source vertices.
+      *  Finally, it does a stable sort in an increasing order of the id of edges.
+      *  Hence, the edges get sorted in the order of id, then source, then target.
+      *
+      *  @param edges
+      */
      template < typename T>
          void sort_edges(std::vector<T> &edges) {
              std::sort(edges.begin(), edges.end(),
@@ -477,6 +497,15 @@ class Pgr_base_graph {
                  });
          }
 
+     /*! @brief Inserts *count* edges of type *T* into the graph in sorted order,
+      *
+      *  Sorts the edges and then for every edge, assets that the corresponding
+      *  vertex exists. Finally, adds the edge to the graph without creating the vertex.
+      *
+      *  @param edges
+      *  @param count
+      *  @param bool
+      */
      template < typename T>
          void insert_edges_sorted(T *edges, int64_t count, bool) {
              sort_edges(edges, count);
@@ -503,32 +532,25 @@ class Pgr_base_graph {
      template <typename T>
      void
      insert_edges_sorted(std::vector<T> edges, bool normal = true) {
-#if 0
-         // This code does not work with contraction
-         if (num_vertices() == 0) {
-             auto vertices = pgrouting::extract_vertices(edges);
-             pgassert(pgrouting::check_vertices(vertices) == 0);
-             add_vertices(vertices);
-         }
-#endif
          sort_edges(edges);
          for (const auto edge : edges) {
              graph_add_edge(edge, normal);
          }
      }
 
+     /*! @brief Inserts *count* edges of type *T* into the graph in sorted order,
+      *
+      *  Converts the edges to a std::vector<T> & calls the overloaded
+      *  twin function, which calls the function to sort the edges
+      *  in an increasing order of their id, then source (if ids are equal)
+      *  and then target (if ids and sources are equal).
+      *
+      *  @param edges
+      *  @param count
+      */
      template <typename T>
      void insert_min_edges_no_parallel_sorted(const T *edges, int64_t count) {
          insert_edges_sorted(std::vector<T>(edges, edges + count));
-     }
-
-     template <typename T>
-     void
-     insert_min_edges_no_parallel_sorted(const std::vector<T> &edges) {
-         sort_edges(edges);
-         for (const auto edge : edges) {
-             graph_add_min_edge_no_parallel_sorted(edge);
-         }
      }
      //@}
 

--- a/pgtap/allpairs/floydWarshall-rows-check.sql
+++ b/pgtap/allpairs/floydWarshall-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_floydWarshall(

--- a/pgtap/allpairs/johnson-rows-check.sql
+++ b/pgtap/allpairs/johnson-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT start_vid, end_vid, agg_cost::TEXT FROM pgr_johnson(

--- a/pgtap/astar/aStarCost-rows-check.sql
+++ b/pgtap/astar/aStarCost-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputCostDirected AS
 SELECT * FROM pgr_astarCost(

--- a/pgtap/astar/astar-rows-check.sql
+++ b/pgtap/astar/astar-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_astar(

--- a/pgtap/bdAstar/bdAstar-rows-check.sql
+++ b/pgtap/bdAstar/bdAstar-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bdAstar(

--- a/pgtap/bdAstar/bdAstarCost-rows-check.sql
+++ b/pgtap/bdAstar/bdAstarCost-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bdAstarCost(

--- a/pgtap/bdDijkstra/bdDijkstra-rows-check.sql
+++ b/pgtap/bdDijkstra/bdDijkstra-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bdDijkstra(

--- a/pgtap/bdDijkstra/bdDijkstraCost-rows-check.sql
+++ b/pgtap/bdDijkstra/bdDijkstraCost-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bdDijkstraCost(

--- a/pgtap/bellman_ford/bellman_ford/bellman_ford-rows-check.sql
+++ b/pgtap/bellman_ford/bellman_ford/bellman_ford-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bellmanFord(

--- a/pgtap/bellman_ford/edwardMoore/edwardMoore-rows-check.sql
+++ b/pgtap/bellman_ford/edwardMoore/edwardMoore-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_edwardMoore(

--- a/pgtap/breadthFirstSearch/binaryBreadthFirstSearch/binaryBreadthFirstSearch-rows-check.sql
+++ b/pgtap/breadthFirstSearch/binaryBreadthFirstSearch/binaryBreadthFirstSearch-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(10);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 -- Creating the table used for the queries
 

--- a/pgtap/breadthFirstSearch/breadthFirstSearch/breadthFirstSearch-rows-check.sql
+++ b/pgtap/breadthFirstSearch/breadthFirstSearch/breadthFirstSearch-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_breadthFirstSearch(

--- a/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
+++ b/pgtap/chinese/chinesePostman/chinesePostman-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_chinesePostman(

--- a/pgtap/chinese/chinesePostmanCost/chinesePostmanCost-rows-check.sql
+++ b/pgtap/chinese/chinesePostmanCost/chinesePostmanCost-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_chinesePostmanCost(

--- a/pgtap/components/articulationPoints/articulationPoints-rows-check.sql
+++ b/pgtap/components/articulationPoints/articulationPoints-rows-check.sql
@@ -2,7 +2,7 @@
 
 SELECT plan(5);
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_articulationPoints(

--- a/pgtap/components/biconnectedComponents/biconnectedComponents-rows-check.sql
+++ b/pgtap/components/biconnectedComponents/biconnectedComponents-rows-check.sql
@@ -2,7 +2,7 @@
 
 SELECT plan(5);
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_biconnectedComponents(

--- a/pgtap/components/bridges/bridges-rows-check.sql
+++ b/pgtap/components/bridges/bridges-rows-check.sql
@@ -2,7 +2,7 @@
 
 SELECT plan(5);
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_bridges(

--- a/pgtap/components/connectedComponents/connectedComponents-rows-check.sql
+++ b/pgtap/components/connectedComponents/connectedComponents-rows-check.sql
@@ -2,7 +2,7 @@
 
 SELECT plan(5);
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_connectedComponents(

--- a/pgtap/components/strongComponents/strongComponents-rows-check.sql
+++ b/pgtap/components/strongComponents/strongComponents-rows-check.sql
@@ -2,7 +2,7 @@
 
 SELECT plan(5);
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_strongComponents(

--- a/pgtap/contraction/contraction-rows-check.sql
+++ b/pgtap/contraction/contraction-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(40);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 -- Without forbidden vertices
 

--- a/pgtap/costMatrix/aStarCostMatrix/aStarCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/aStarCostMatrix/aStarCostMatrix-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_aStarCostMatrix(

--- a/pgtap/costMatrix/bdAstarCostMatrix/bdAstarCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/bdAstarCostMatrix/bdAstarCostMatrix-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bdAstarCostMatrix(

--- a/pgtap/costMatrix/bdDijkstraCostMatrix/bdDijkstraCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/bdDijkstraCostMatrix/bdDijkstraCostMatrix-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(20);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_bdDijkstraCostMatrix(

--- a/pgtap/costMatrix/dijkstraCostMatrix/dijkstraCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/dijkstraCostMatrix/dijkstraCostMatrix-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_dijkstraCostMatrix(

--- a/pgtap/costMatrix/withPointsCostMatrix/withPointsCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/withPointsCostMatrix/withPointsCostMatrix-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_withPointsCostMatrix(

--- a/pgtap/dagShortestPath/dagShortestPath-rows-check.sql
+++ b/pgtap/dagShortestPath/dagShortestPath-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(10);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_dagShortestPath(

--- a/pgtap/dijkstra/dijkstra-rows-check.sql
+++ b/pgtap/dijkstra/dijkstra-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_dijkstra(

--- a/pgtap/dijkstra/dijkstraCost-rows-check.sql
+++ b/pgtap/dijkstra/dijkstraCost-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_dijkstraCost(

--- a/pgtap/dijkstra/dijkstraVia-rows-check.sql
+++ b/pgtap/dijkstra/dijkstraVia-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(40);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 -- DIRECTED
 

--- a/pgtap/driving_distance/dijkstraDD-rows-check.sql
+++ b/pgtap/driving_distance/dijkstraDD-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_drivingDistance(

--- a/pgtap/driving_distance/withPointsDD-rows-check.sql
+++ b/pgtap/driving_distance/withPointsDD-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_withPointsDD(

--- a/pgtap/ksp/ksp-rows-check.sql
+++ b/pgtap/ksp/ksp-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(40);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 -- DIRECTED
 

--- a/pgtap/ksp/withPointsKSP-rows-check.sql
+++ b/pgtap/ksp/withPointsKSP-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(40);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 -- DIRECTED
 

--- a/pgtap/lineGraph/lineGraph/lineGraph-rows-check.sql
+++ b/pgtap/lineGraph/lineGraph/lineGraph-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_lineGraph(

--- a/pgtap/lineGraph/lineGraphFull/lineGraphFull-rows-check.sql
+++ b/pgtap/lineGraph/lineGraphFull/lineGraphFull-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(10);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_lineGraphFull(

--- a/pgtap/max_flow/boykovKolmogorov-rows-check.sql
+++ b/pgtap/max_flow/boykovKolmogorov-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(10);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_boykovKolmogorov(

--- a/pgtap/max_flow/edgeDisjointPaths-rows-check.sql
+++ b/pgtap/max_flow/edgeDisjointPaths-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_edgeDisjointPaths(

--- a/pgtap/max_flow/edmondsKarp-rows-check.sql
+++ b/pgtap/max_flow/edmondsKarp-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(10);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_edmondsKarp(

--- a/pgtap/max_flow/maxCardinalityMatch-rows-check.sql
+++ b/pgtap/max_flow/maxCardinalityMatch-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_maxCardinalityMatch(

--- a/pgtap/max_flow/maxFlow/maxFlow-rows-check.sql
+++ b/pgtap/max_flow/maxFlow/maxFlow-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(10);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_maxFlow(

--- a/pgtap/max_flow/maxFlowMinCost/maxFlowMinCost-rows-check.sql
+++ b/pgtap/max_flow/maxFlowMinCost/maxFlowMinCost-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_maxFlowMinCost(

--- a/pgtap/max_flow/maxFlowMinCost/maxFlowMinCost_Cost-rows-check.sql
+++ b/pgtap/max_flow/maxFlowMinCost/maxFlowMinCost_Cost-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_maxFlowMinCost_Cost(

--- a/pgtap/max_flow/pushRelabel-rows-check.sql
+++ b/pgtap/max_flow/pushRelabel-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(10);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_pushRelabel(

--- a/pgtap/mincut/stoerWagner-rows-check.sql
+++ b/pgtap/mincut/stoerWagner-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_stoerWagner(

--- a/pgtap/pickDeliver/pickDeliver/pickDeliver-rows-check.sql
+++ b/pgtap/pickDeliver/pickDeliver/pickDeliver-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(10);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_pickDeliver(

--- a/pgtap/pickDeliver/pickDeliverEuclidean/pickDeliverEuclidean-rows-check.sql
+++ b/pgtap/pickDeliver/pickDeliverEuclidean/pickDeliverEuclidean-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(5);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_pickDeliverEuclidean(

--- a/pgtap/topologicalSort/topologicalSort-rows-check.sql
+++ b/pgtap/topologicalSort/topologicalSort-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_topologicalSort(

--- a/pgtap/topology/extractVertices/extractVertices-rows-check.sql
+++ b/pgtap/topology/extractVertices/extractVertices-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(5);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT  * FROM pgr_extractVertices(

--- a/pgtap/transitiveClosure/transitiveClosure-rows-check.sql
+++ b/pgtap/transitiveClosure/transitiveClosure-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_transitiveClosure(

--- a/pgtap/tsp/TSPeuclidean/tspEuclidean-rows-check.sql
+++ b/pgtap/tsp/TSPeuclidean/tspEuclidean-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(5);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT seq, node, cost::TEXT, agg_cost::TEXT FROM pgr_TSPeuclidean(

--- a/pgtap/tsp/tsp-rows-check.sql
+++ b/pgtap/tsp/tsp-rows-check.sql
@@ -3,7 +3,7 @@
 SELECT plan(10);
 
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutput AS
 SELECT * FROM pgr_TSP(

--- a/pgtap/withPoints/withPoints-rows-check.sql
+++ b/pgtap/withPoints/withPoints-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_withPoints(

--- a/pgtap/withPoints/withPointsCost-rows-check.sql
+++ b/pgtap/withPoints/withPointsCost-rows-check.sql
@@ -4,7 +4,7 @@ SELECT plan(20);
 
 SET extra_float_digits = -3;
 
--- Check whether the same set of rows are returned always
+-- Check whether the same set of rows is always returned
 
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_withPointsCost(


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixing grammar in pgTAP tests
- Changes "Check whether the same set of rows are returned always" to "Check whether the same set of rows is always returned"
- Added documentation of the functions in the `pgr_base_graph.hpp` file

@pgRouting/admins
