### PR TITLE
Closes #78 fixing breadthFirstSearch ordering issue

### DIFF
--- a/pgtap/breadthFirstSearch/binaryBreadthFirstSearch/binaryBreadthFirstSearch-rows-check.sql
+++ b/pgtap/breadthFirstSearch/binaryBreadthFirstSearch/binaryBreadthFirstSearch-rows-check.sql
@@ -1,0 +1,106 @@
+\i setup.sql
+
+SELECT plan(10);
+
+
+-- Check whether the same set of rows is always returned
+
+-- Creating the table used for the queries
+
+DROP TABLE IF EXISTS roadworks CASCADE;
+
+CREATE table roadworks (
+    id BIGINT not null primary key,
+    source BIGINT,
+    target BIGINT,
+    road_work FLOAT,
+    reverse_road_work FLOAT
+);
+
+INSERT INTO roadworks(
+  id, source, target, road_work, reverse_road_work) VALUES
+  (1,  1,  2,  0,  0),
+  (2,  2,  3,  -1,  1),
+  (3,  3,  4,  -1,  0),
+  (4,  2,  5,  0,  0),
+  (5,  3,  6,  1,  -1),
+  (6,  7,  8,  1,  1),
+  (7,  8,  5,  0,  0),
+  (8,  5,  6,  1,  1),
+  (9,  6,  9,  1,  1),
+  (10,  5,  10,  1,  1),
+  (11,  6,  11,  1,  -1),
+  (12,  10,  11,  0,  -1),
+  (13,  11,  12,  1,  -1),
+  (14,  10,  13,  1,  1),
+  (15,  9,  12,  0,  0),
+  (16,  4,  9,  0,  0),
+  (17,  14,  15,  0,  0),
+  (18,  16,  17,  0,  0);
+
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_binaryBreadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_binaryBreadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_binaryBreadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_binaryBreadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_binaryBreadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_binaryBreadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/breadthFirstSearch/binaryBreadthFirstSearch/binaryBreadthFirstSearch-rows-check.sql
+++ b/pgtap/breadthFirstSearch/binaryBreadthFirstSearch/binaryBreadthFirstSearch-rows-check.sql
@@ -5,40 +5,6 @@ SELECT plan(10);
 
 -- Check whether the same set of rows is always returned
 
--- Creating the table used for the queries
-
-DROP TABLE IF EXISTS roadworks CASCADE;
-
-CREATE table roadworks (
-    id BIGINT not null primary key,
-    source BIGINT,
-    target BIGINT,
-    road_work FLOAT,
-    reverse_road_work FLOAT
-);
-
-INSERT INTO roadworks(
-  id, source, target, road_work, reverse_road_work) VALUES
-  (1,  1,  2,  0,  0),
-  (2,  2,  3,  -1,  1),
-  (3,  3,  4,  -1,  0),
-  (4,  2,  5,  0,  0),
-  (5,  3,  6,  1,  -1),
-  (6,  7,  8,  1,  1),
-  (7,  8,  5,  0,  0),
-  (8,  5,  6,  1,  1),
-  (9,  6,  9,  1,  1),
-  (10,  5,  10,  1,  1),
-  (11,  6,  11,  1,  -1),
-  (12,  10,  11,  0,  -1),
-  (13,  11,  12,  1,  -1),
-  (14,  10,  13,  1,  1),
-  (15,  9,  12,  0,  0),
-  (16,  4,  9,  0,  0),
-  (17,  14,  15,  0,  0),
-  (18,  16,  17,  0,  0);
-
-
 PREPARE expectedOutputDirected AS
 SELECT * FROM pgr_binaryBreadthFirstSearch(
     'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2

--- a/pgtap/breadthFirstSearch/breadthFirstSearch/breadthFirstSearch-rows-check.sql
+++ b/pgtap/breadthFirstSearch/breadthFirstSearch/breadthFirstSearch-rows-check.sql
@@ -1,0 +1,87 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_breadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2]
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_breadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2]
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_breadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2]
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_breadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2],
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_breadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2],
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_breadthFirstSearch(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/binaryBreadthFirstSearch_driver.cpp
@@ -141,7 +141,7 @@ do_pgr_binaryBreadthFirstSearch(
         if (directed) {
             // log << "\nWorking with directed Graph";
             pgrouting::DirectedGraph digraph(gType);
-            digraph.insert_edges(data_edges, total_edges);
+            digraph.insert_edges_sorted(data_edges, total_edges);
 
             if (!(costCheck(digraph))) {
                 err << COST_ERR_MSG;
@@ -156,7 +156,7 @@ do_pgr_binaryBreadthFirstSearch(
         } else {
             // log << "\nWorking with Undirected Graph";
             pgrouting::UndirectedGraph undigraph(gType);
-            undigraph.insert_edges(data_edges, total_edges);
+            undigraph.insert_edges_sorted(data_edges, total_edges);
 
             if (!(costCheck(undigraph))) {
                 err << COST_ERR_MSG;

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -88,10 +88,11 @@ do_pgr_breadthFirstSearch(
             start_vertices(start_vidsArr, start_vidsArr + size_start_vidsArr);
 
         std::vector<pgr_mst_rt> results;
+        std::string logstr;
         if (directed) {
             log << "Working with directed Graph\n";
             pgrouting::DirectedGraph digraph(gType);
-            digraph.insert_edges(data_edges, total_edges);
+            digraph.insert_edges_sorted(data_edges, total_edges);
             results = pgr_breadthFirstSearch(
                     digraph,
                     start_vertices,
@@ -100,7 +101,7 @@ do_pgr_breadthFirstSearch(
         } else {
             log << "Working with Undirected Graph\n";
             pgrouting::UndirectedGraph undigraph(gType);
-            undigraph.insert_edges(data_edges, total_edges);
+            undigraph.insert_edges_sorted(data_edges, total_edges);
 
             results = pgr_breadthFirstSearch(
                     undigraph,

--- a/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
+++ b/src/breadthFirstSearch/breadthFirstSearch_driver.cpp
@@ -88,7 +88,6 @@ do_pgr_breadthFirstSearch(
             start_vertices(start_vidsArr, start_vidsArr + size_start_vidsArr);
 
         std::vector<pgr_mst_rt> results;
-        std::string logstr;
         if (directed) {
             log << "Working with directed Graph\n";
             pgrouting::DirectedGraph digraph(gType);


### PR DESCRIPTION
Fixes #78.

Changes proposed in this pull request:
- Adds pgTAP tests for breadthFirstSearch that check the output after rows ordering.
-
-

@pgRouting/admins
