### PR TITLE
Fixing astar ordering issue

### DIFF
--- a/pgtap/astar/aStarCost-rows-check.sql
+++ b/pgtap/astar/aStarCost-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputCostDirected AS
+SELECT * FROM pgr_astarCost(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE descendingOrderCostDirected AS
+SELECT * FROM pgr_astarCost(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE randomOrderCostDirected AS
+SELECT * FROM pgr_astarCost(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE expectedOutputCostUndirected AS
+SELECT * FROM pgr_astarCost(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+PREPARE descendingOrderCostUndirected AS
+SELECT * FROM pgr_astarCost(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+PREPARE randomOrderCostUndirected AS
+SELECT * FROM pgr_astarCost(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputCostDirected', 'descendingOrderCostDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputCostUndirected', 'descendingOrderCostUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputCostDirected', 'descendingOrderCostDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputCostDirected', 'randomOrderCostDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputCostUndirected', 'descendingOrderCostUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputCostUndirected', 'randomOrderCostUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/astar/astar-rows-check.sql
+++ b/pgtap/astar/astar-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_astar(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_astar(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_astar(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], ARRAY[3, 12]
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_astar(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_astar(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_astar(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], ARRAY[3, 12],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/astar/astar_driver.cpp
+++ b/src/astar/astar_driver.cpp
@@ -123,7 +123,7 @@ void do_pgr_astarManyToMany(
             pgrouting::xyDirectedGraph digraph(
                     pgrouting::extract_vertices(edges, total_edges),
                     gType);
-            digraph.insert_edges(edges, total_edges);
+            digraph.insert_edges_sorted(edges, total_edges);
             paths = pgr_astar(digraph, start_vids, end_vids,
                     heuristic, factor, epsilon, only_cost, normal);
         } else {
@@ -131,7 +131,7 @@ void do_pgr_astarManyToMany(
             pgrouting::xyUndirectedGraph undigraph(
                     pgrouting::extract_vertices(edges, total_edges),
                     gType);
-            undigraph.insert_edges(edges, total_edges);
+            undigraph.insert_edges_sorted(edges, total_edges);
             paths = pgr_astar(undigraph, start_vids, end_vids,
                     heuristic, factor, epsilon, only_cost, normal);
         }


### PR DESCRIPTION
astar on #68

Changes proposed in this pull request:
- Adds pgTAP tests for astar algorithm that check the output after rows ordering.
- Fixes the code, by calling the function that sorts the input rows before creating the graph.

@pgRouting/admins
