### PR TITLE
Fixing bdDijkstra ordering issue

### DIFF
--- a/pgtap/bdDijkstra/bdDijkstra-rows-check.sql
+++ b/pgtap/bdDijkstra/bdDijkstra-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_bdDijkstra(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[2, 7], ARRAY[3, 11]
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_bdDijkstra(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[2, 7], ARRAY[3, 11]
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_bdDijkstra(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[2, 7], ARRAY[3, 11]
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_bdDijkstra(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[2, 7], ARRAY[3, 11],
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_bdDijkstra(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[2, 7], ARRAY[3, 11],
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_bdDijkstra(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[2, 7], ARRAY[3, 11],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/bdDijkstra/bdDijkstraCost-rows-check.sql
+++ b/pgtap/bdDijkstra/bdDijkstraCost-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_bdDijkstraCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[2, 7], ARRAY[3, 11]
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_bdDijkstraCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[2, 7], ARRAY[3, 11]
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_bdDijkstraCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[2, 7], ARRAY[3, 11]
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_bdDijkstraCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[2, 7], ARRAY[3, 11],
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_bdDijkstraCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[2, 7], ARRAY[3, 11],
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_bdDijkstraCost(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[2, 7], ARRAY[3, 11],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/bdDijkstra/bdDijkstra_driver.cpp
+++ b/src/bdDijkstra/bdDijkstra_driver.cpp
@@ -128,7 +128,7 @@ do_pgr_bdDijkstra(
         if (directed) {
             log << "Working with directed Graph\n";
             pgrouting::DirectedGraph digraph(gType);
-            digraph.insert_edges(data_edges, total_edges);
+            digraph.insert_edges_sorted(data_edges, total_edges);
             paths = pgr_bdDijkstra(digraph,
                     start_vertices,
                     end_vertices,
@@ -137,7 +137,7 @@ do_pgr_bdDijkstra(
         } else {
             log << "Working with Undirected Graph\n";
             pgrouting::UndirectedGraph undigraph(gType);
-            undigraph.insert_edges(data_edges, total_edges);
+            undigraph.insert_edges_sorted(data_edges, total_edges);
             paths = pgr_bdDijkstra(
                     undigraph,
                     start_vertices,


### PR DESCRIPTION
bdDijkstra on #68.

Changes proposed in this pull request:
- Adds pgTAP tests for bdDijkstra directory that check the output after rows ordering.
- Fixes the code, by calling the function that sorts the input rows before creating the graph.

@pgRouting/admins
