### PR TITLE
Fixing costMatrix ordering issue

### DIFF
--- a/pgtap/costMatrix/aStarCostMatrix/aStarCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/aStarCostMatrix/aStarCostMatrix-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_aStarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_aStarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_aStarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_aStarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_aStarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_aStarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/costMatrix/bdAstarCostMatrix/bdAstarCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/bdAstarCostMatrix/bdAstarCostMatrix-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_bdAstarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_bdAstarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_bdAstarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_bdAstarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_bdAstarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_bdAstarCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost, x1, y1, x2, y2
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/costMatrix/bdDijkstraCostMatrix/bdDijkstraCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/bdDijkstraCostMatrix/bdDijkstraCostMatrix-rows-check.sql
@@ -1,0 +1,86 @@
+\i setup.sql
+
+SELECT plan(20);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_bdDijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_bdDijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_bdDijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_bdDijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_bdDijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_bdDijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/costMatrix/dijkstraCostMatrix/dijkstraCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/dijkstraCostMatrix/dijkstraCostMatrix-rows-check.sql
@@ -1,0 +1,87 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_dijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_dijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_dijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr)
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_dijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_dijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_dijkstraCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    (SELECT array_agg(id) FROM edge_table_vertices_pgr),
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/costMatrix/withPointsCostMatrix/withPointsCostMatrix-rows-check.sql
+++ b/pgtap/costMatrix/withPointsCostMatrix/withPointsCostMatrix-rows-check.sql
@@ -1,0 +1,99 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    ARRAY[-1, 2, 7, -3, 12, 3]
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    ARRAY[-1, 2, 7, -3, 12, 3]
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    ARRAY[-1, 2, 7, -3, 12, 3]
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    ARRAY[-1, 2, 7, -3, 12, 3],
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    ARRAY[-1, 2, 7, -3, 12, 3],
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_withPointsCostMatrix(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    ARRAY[-1, 2, 7, -3, 12, 3],
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
costMatrix on #68.

Changes proposed in this pull request:
- Adds pgTAP tests for costMatrix directory that check the output after rows ordering.

@pgRouting/admins
