### PR TITLE
Fixing dagShortestPath ordering issue

### DIFF
--- a/pgtap/dagShortestPath/dagShortestPath-rows-check.sql
+++ b/pgtap/dagShortestPath/dagShortestPath-rows-check.sql
@@ -1,0 +1,47 @@
+\i setup.sql
+
+SELECT plan(10);
+
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_dagShortestPath(
+    'SELECT id, source, target, cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[10, 2], ARRAY[11, 12]
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_dagShortestPath(
+    'SELECT id, source, target, cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[10, 2], ARRAY[11, 12]
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_dagShortestPath(
+    'SELECT id, source, target, cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[10, 2], ARRAY[11, 12]
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/dagShortestPath/dagShortestPath_driver.cpp
+++ b/src/dagShortestPath/dagShortestPath_driver.cpp
@@ -116,7 +116,7 @@ do_pgr_dagShortestPath(
         if (directed) {
             log << "Working with directed Graph\n";
             pgrouting::DirectedGraph digraph(gType);
-            digraph.insert_edges(data_edges, total_edges);
+            digraph.insert_edges_sorted(data_edges, total_edges);
             paths = pgr_dagShortestPath(digraph,
                     start_vertices,
                     end_vertices,
@@ -124,7 +124,7 @@ do_pgr_dagShortestPath(
         } else {
             log << "Working with Undirected Graph\n";
             pgrouting::UndirectedGraph undigraph(gType);
-            undigraph.insert_edges(data_edges, total_edges);
+            undigraph.insert_edges_sorted(data_edges, total_edges);
             paths = pgr_dagShortestPath(
                     undigraph,
                     start_vertices,


### PR DESCRIPTION
dagShortestPath on #68.

Changes proposed in this pull request:
- Adds pgTAP tests for dagShortestPath directory that check the output after rows ordering.

@pgRouting/admins
