### PR TITLE
Fixing driving_distance ordering issue

### DIFF
--- a/pgtap/driving_distance/dijkstraDD-rows-check.sql
+++ b/pgtap/driving_distance/dijkstraDD-rows-check.sql
@@ -1,0 +1,88 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_drivingDistance(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], 10
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_drivingDistance(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], 10
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_drivingDistance(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], 10
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_drivingDistance(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    ARRAY[7, 2], 10,
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_drivingDistance(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    ARRAY[7, 2], 10,
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_drivingDistance(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    ARRAY[7, 2], 10,
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/driving_distance/withPointsDD-rows-check.sql
+++ b/pgtap/driving_distance/withPointsDD-rows-check.sql
@@ -1,0 +1,100 @@
+\i setup.sql
+
+SELECT plan(20);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutputDirected AS
+SELECT * FROM pgr_withPointsDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    -1, 8.8
+);
+
+PREPARE descendingOrderDirected AS
+SELECT * FROM pgr_withPointsDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    -1, 8.8
+);
+
+PREPARE randomOrderDirected AS
+SELECT * FROM pgr_withPointsDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    -1, 8.8
+);
+
+PREPARE expectedOutputUndirected AS
+SELECT * FROM pgr_withPointsDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    -1, 8.8,
+    directed => false
+);
+
+PREPARE descendingOrderUndirected AS
+SELECT * FROM pgr_withPointsDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    -1, 8.8,
+    directed => false
+);
+
+PREPARE randomOrderUndirected AS
+SELECT * FROM pgr_withPointsDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    'SELECT pid, edge_id, fraction, side
+    FROM pointsOfInterest',
+    -1, 8.8,
+    directed => false
+);
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '1: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '2: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '3: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '4: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '5: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '6: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '7: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '8: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '9: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '10: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutputDirected', 'descendingOrderDirected', '11: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '12: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '13: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '14: Should return same set of rows');
+SELECT set_eq('expectedOutputDirected', 'randomOrderDirected', '15: Should return same set of rows');
+
+SELECT set_eq('expectedOutputUndirected', 'descendingOrderUndirected', '16: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '17: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '18: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '19: Should return same set of rows');
+SELECT set_eq('expectedOutputUndirected', 'randomOrderUndirected', '20: Should return same set of rows');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/driving_distance/drivedist_driver.cpp
+++ b/src/driving_distance/drivedist_driver.cpp
@@ -131,7 +131,7 @@ do_pgr_driving_many_to_dist(
             log << "********Inserting edges at time: " << std::ctime(&start_t)
                 << "\n";
 #endif
-            digraph.insert_edges(data_edges, total_edges, true);
+            digraph.insert_edges_sorted(data_edges, total_edges, true);
 #ifdef WITH_TIME
             end_timing(start_t, begin_elapsed, begin, log);
 #endif
@@ -162,7 +162,7 @@ do_pgr_driving_many_to_dist(
             log << "*******Inserting edges at time: " << std::ctime(&start_t)
                 << "\n";
 #endif
-            undigraph.insert_edges(data_edges, total_edges, true);
+            undigraph.insert_edges_sorted(data_edges, total_edges, true);
 #ifdef WITH_TIME
             end_timing(start_t, begin_elapsed, begin, log);
 #endif


### PR DESCRIPTION
driving_distance on #68.

Changes proposed in this pull request:
- Adds pgTAP tests for driving_distance directory that check the output after rows ordering.

@pgRouting/admins
