### PR TITLE
Fixing spanningTree ordering issue

### DIFF
--- a/pgtap/spanningTree/kruskal/kruskal/kruskal-rows-check.sql
+++ b/pgtap/spanningTree/kruskal/kruskal/kruskal-rows-check.sql
@@ -1,0 +1,46 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_kruskal(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id'
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_kruskal(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_kruskal(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()'
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/kruskal/kruskalBFS/kruskalBFS-rows-check.sql
+++ b/pgtap/spanningTree/kruskal/kruskalBFS/kruskalBFS-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_kruskalBFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    2
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_kruskalBFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    2
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_kruskalBFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    2
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/kruskal/kruskalDD/kruskalDD-rows-check.sql
+++ b/pgtap/spanningTree/kruskal/kruskalDD/kruskalDD-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_kruskalDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    2, 3.5
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_kruskalDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    2, 3.5
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_kruskalDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    2, 3.5
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/kruskal/kruskalDFS/kruskalDFS-rows-check.sql
+++ b/pgtap/spanningTree/kruskal/kruskalDFS/kruskalDFS-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_kruskalDFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    2
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_kruskalDFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    2
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_kruskalDFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    2
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/prim/prim/prim-rows-check.sql
+++ b/pgtap/spanningTree/prim/prim/prim-rows-check.sql
@@ -1,0 +1,46 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_prim(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id'
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_prim(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_prim(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()'
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/prim/primBFS/primBFS-rows-check.sql
+++ b/pgtap/spanningTree/prim/primBFS/primBFS-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_primBFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    2
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_primBFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    2
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_primBFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    2
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/prim/primDD/primDD-rows-check.sql
+++ b/pgtap/spanningTree/prim/primDD/primDD-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_primDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    2, 3.5
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_primDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    2, 3.5
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_primDD(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    2, 3.5
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/pgtap/spanningTree/prim/primDFS/primDFS-rows-check.sql
+++ b/pgtap/spanningTree/prim/primDFS/primDFS-rows-check.sql
@@ -1,0 +1,48 @@
+\i setup.sql
+
+SELECT plan(10);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows are returned always
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_primDFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id',
+    2
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_primDFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY id DESC',
+    2
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_primDFS(
+    'SELECT id, source, target, cost, reverse_cost
+    FROM edge_table
+    ORDER BY RANDOM()',
+    2
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+UPDATE edge_table SET cost = cost + 0.001 * id * id, reverse_cost = reverse_cost + 0.001 * id * id;
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '6: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '7: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '8: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '9: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '10: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/spanningTree/kruskal_driver.cpp
+++ b/src/spanningTree/kruskal_driver.cpp
@@ -78,7 +78,7 @@ do_pgr_kruskal(
             results = pgrouting::details::get_no_edge_graph_result(roots);
         } else {
             pgrouting::UndirectedGraph undigraph(UNDIRECTED);
-            undigraph.insert_edges(data_edges, total_edges);
+            undigraph.insert_edges_sorted(data_edges, total_edges);
 
             pgrouting::functions::Pgr_kruskal
                 <pgrouting::UndirectedGraph> kruskal;

--- a/src/spanningTree/prim_driver.cpp
+++ b/src/spanningTree/prim_driver.cpp
@@ -78,7 +78,7 @@ do_pgr_prim(
             results = pgrouting::details::get_no_edge_graph_result(roots);
         } else {
             pgrouting::UndirectedGraph undigraph(UNDIRECTED);
-            undigraph.insert_min_edges_no_parallel(data_edges, total_edges);
+            undigraph.insert_min_edges_no_parallel_sorted(data_edges, total_edges);
             pgrouting::functions::Pgr_prim<pgrouting::UndirectedGraph> prim;
             if (suffix == "") {
                 results = prim.prim(undigraph);


### PR DESCRIPTION
spanningTree on #68.

Changes proposed in this pull request:
- Adds pgTAP tests for spanningTree directory that check the output after rows ordering.

@pgRouting/admins
