### PR TITLE
Fixing topologicalSort ordering issue

### DIFF
--- a/pgtap/topologicalSort/topologicalSort-rows-check.sql
+++ b/pgtap/topologicalSort/topologicalSort-rows-check.sql
@@ -1,0 +1,37 @@
+\i setup.sql
+
+SELECT plan(5);
+
+SET extra_float_digits = -3;
+
+-- Check whether the same set of rows is always returned
+
+PREPARE expectedOutput AS
+SELECT * FROM pgr_topologicalSort(
+    'SELECT id, source, target, cost
+    FROM edge_table
+    ORDER BY id'
+);
+
+PREPARE descendingOrder AS
+SELECT * FROM pgr_topologicalSort(
+    'SELECT id, source, target, cost
+    FROM edge_table
+    ORDER BY id DESC'
+);
+
+PREPARE randomOrder AS
+SELECT * FROM pgr_topologicalSort(
+    'SELECT id, source, target, cost
+    FROM edge_table
+    ORDER BY RANDOM()'
+);
+
+SELECT set_eq('expectedOutput', 'descendingOrder', '1: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '2: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '3: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '4: Should return same set of rows');
+SELECT set_eq('expectedOutput', 'randomOrder', '5: Should return same set of rows');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/topologicalSort/topologicalSort_driver.cpp
+++ b/src/topologicalSort/topologicalSort_driver.cpp
@@ -82,7 +82,7 @@ do_pgr_topologicalSort(
 
         log << "Working with Directed Graph\n";
         pgrouting::DirectedGraph digraph(gType);
-        digraph.insert_edges(data_edges, total_edges);
+        digraph.insert_edges_sorted(data_edges, total_edges);
         results = pgr_topologicalSort(
                 digraph);
 


### PR DESCRIPTION
topologicalSort on #68.

Changes proposed in this pull request:
- Adds pgTAP tests for topologicalSort directory that check the output after rows ordering.

@pgRouting/admins
