### PR TITLE
Task 2 : Add name in Contributor List

### DIFF
--- a/doc/src/pgRouting-introduction.rst
+++ b/doc/src/pgRouting-introduction.rst
@@ -100,7 +100,7 @@ Kai Behncke, Kishore Kumar, Ko Nagase,
 Mahmoud Sakr,
 Manikata Kondeti, Mario Basa, Martin Wiesenhaan,  Maxim Dubinin, Maoguang Wang, Mohamed Bakli, Mohamed Zia, Mukul Priya,
 Razequl Islam,
-Regina Obe, Rohith Reddy,
+Regina Obe, Rohith Reddy, Rishi Sethia,
 Sarthak Agarwal, Sourabh Garg, Stephen Woodbridge, Sylvain Housseman, Sylvain Pasche,
 Vidhan Jain, Virginia Vergara
 


### PR DESCRIPTION
Changes proposed in this pull request:
-  Add name for Task 2
@pgRouting/admins
