### PR TITLE
Add cycle graph test for pgr_cuthillMckeeOrdering

### DIFF
--- a/pgtap/ordering/cuthillMckeeOrdering/edge_cases.pg
+++ b/pgtap/ordering/cuthillMckeeOrdering/edge_cases.pg
@@ -1,4 +1,3 @@
-
 /*PGR-GNU*****************************************************************
 
 Copyright (c) 2018  pgRouting developers
@@ -20,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 BEGIN;
 
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE WHEN NOT min_version('3.4.0') THEN plan(1) ELSE plan(11) END;
+SELECT CASE WHEN NOT min_version('3.4.0') THEN plan(1) ELSE plan(13) END;
 
 
 CREATE OR REPLACE FUNCTION edge_cases()
@@ -167,6 +166,47 @@ IF version() LIKE '%SQL 14%' THEN
   PERFORM todo('test failing with postgres 14',1);
 END IF;
 RETURN QUERY SELECT set_eq('q11','r11','sample data graph of pgRouting');
+
+-- Cycle graph test
+
+CREATE TABLE cycle_graph_table (
+  id BIGSERIAL,
+  source BIGINT,
+  target BIGINT,
+  cost FLOAT,
+  reverse_cost FLOAT
+);
+
+INSERT INTO cycle_graph_table (source, target, cost, reverse_cost) VALUES
+  (1, 2, 1, 1), -- Edge 1->2
+  (2, 3, 1, 1), -- Edge 2->3
+  (3, 4, 1, 1), -- Edge 3->4
+  (4, 1, 1, 1); -- Edge 4->1
+
+PREPARE q12 AS
+SELECT id, source, target, cost, reverse_cost
+FROM cycle_graph_table;
+
+
+RETURN QUERY
+SELECT set_eq('q12', $$VALUES 
+  (1, 1, 2, 1, 1), -- Edge 1->2
+  (2, 2, 3, 1, 1), -- Edge 2->3
+  (3, 3, 4, 1, 1), -- Edge 3->4
+  (4, 4, 1, 1, 1)$$, -- Edge 4->1
+  'q12: Cycle graph with 4 vertices');
+
+PREPARE r13 AS
+SELECT *
+FROM pgr_cuthillMckeeOrdering('q12');
+
+RETURN QUERY
+SELECT set_eq('r13', $$VALUES 
+  (1, 1), -- Vertex 1 is placed first
+  (2, 4), -- Vertex 4 is placed second
+  (3, 2), -- Vertex 2 is placed third
+  (4, 3)$$, -- Vertex 3 is placed fourth
+  'r13: Cycle graph ordering');
 
 END;
 $BODY$


### PR DESCRIPTION
### Changes proposed in this pull request:
- Added a new cycle graph test in `pgtap/ordering/cuthillMckeeOrdering/edge_cases.pg`.
- Verified the test output using pgTAP.

### Test Output
Below is the pgTAP test output for the changes:
```bash
Test Summary Report
-------------------
pgtap/ordering/cuthillMckeeOrdering/edge_cases.pg (Wstat: 0 Tests: 13 Failed: 0)
  TODO passed:   11
Files=1, Tests=13,  0 wallclock secs ( 0.01 usr +  0.00 sys =  0.01 CPU)
Result: PASS
```
@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test case that evaluates graph ordering using a cycle graph scenario, ensuring vertices are ordered as expected.
  - Updated test validation logic to align with the enhanced cycle graph scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->