### PR TITLE
Week 7 sloanordering

### DIFF
--- a/docqueries/ordering/sloanOrdering.pg
+++ b/docqueries/ordering/sloanOrdering.pg
@@ -2,6 +2,30 @@
 -- Creative Commons Attribution-Share Alike 3.0 License : https://creativecommons.org/licenses/by-sa/3.0/
 /* -- q1 */
 SELECT * FROM pgr_sloanOrdering(
-  'SELECT id, source, target, cost, reverse_cost FROM edges WHERE id < 2'
+  'SELECT id, source, target, cost, reverse_cost FROM edges'
   );
 /* -- q2 */
+
+CREATE TABLE expected_result (
+   seq BIGINT,
+   node BIGINT);
+
+INSERT INTO expected_result (seq, node) VALUES
+(1,13),
+(2,14),
+(3,2),
+(4,4),
+(5,9),
+(6,1),
+(7,8),
+(8,3),
+(9,12),
+(10,7),
+(11,5),
+(12,17),
+(13,11),
+(14,6),
+(15,16),
+(16,10),
+(17,15);
+

--- a/docqueries/ordering/sloanOrdering.result
+++ b/docqueries/ordering/sloanOrdering.result
@@ -8,8 +8,9 @@ SELECT * FROM pgr_sloanOrdering(
   );
  seq | node
 -----+------
-   1 |    1
-(1 row)
+   1 |    5
+   2 |    6
+(2 rows)
 
 /* -- q2 */
 ROLLBACK;

--- a/docqueries/ordering/sloanOrdering.result
+++ b/docqueries/ordering/sloanOrdering.result
@@ -4,14 +4,52 @@ SET client_min_messages TO NOTICE;
 SET
 /* -- q1 */
 SELECT * FROM pgr_sloanOrdering(
-  'SELECT id, source, target, cost, reverse_cost FROM edges WHERE id < 2'
+  'SELECT id, source, target, cost, reverse_cost FROM edges'
   );
  seq | node
 -----+------
-   1 |    5
-   2 |    6
-(2 rows)
+   1 |    1
+   2 |    3
+   3 |    6
+   4 |    5
+   5 |   10
+   6 |    7
+   7 |    9
+   8 |   15
+   9 |    8
+  10 |   11
+  11 |   16
+  12 |   12
+  13 |   17
+  14 |    1
+  15 |    1
+  16 |    1
+  17 |    1
+(17 rows)
 
 /* -- q2 */
+CREATE TABLE expected_result (
+   seq BIGINT,
+   node BIGINT);
+CREATE TABLE
+INSERT INTO expected_result (seq, node) VALUES
+(1,13),
+(2,14),
+(3,2),
+(4,4),
+(5,9),
+(6,1),
+(7,8),
+(8,3),
+(9,12),
+(10,7),
+(11,5),
+(12,17),
+(13,11),
+(14,6),
+(15,16),
+(16,10),
+(17,15);
+INSERT 0 17
 ROLLBACK;
 ROLLBACK

--- a/include/ordering/sloanOrdering.hpp
+++ b/include/ordering/sloanOrdering.hpp
@@ -52,37 +52,28 @@ namespace pgrouting {
 
 template <class G>
 std::vector<int64_t>
-        sloanOrdering(G &graph) {
-             typedef boost::adjacency_list<
-                     boost::vecS,boost::vecS,
-                     boost::undirectedS,
-                     boost::property<boost::vertex_color_t,
-                     boost::default_color_type,
-                     boost::property<boost::vertex_degree_t,
-                     int,
-                     boost::property<boost::vertex_priority_t,
-                     int>>>> GraphType;
+sloanOrdering(G &graph) {
              typedef typename boost::graph_traits<typename G::graph_t>::vertex_descriptor Vertex;
-                std::vector<int64_t>results;
+             std::vector<int64_t>results;
 
-        auto i_map = boost::get(boost::vertex_index, graph.graph);
-        auto color_map = boost::get(boost::vertex_color, graph.graph);
-        auto degree_map = boost::make_degree_map(graph.graph);
-        auto priority_map = boost::get(boost::vertex_priority, graph.graph);
+             auto i_map = boost::get(boost::vertex_index, graph.graph);
+             auto color_map = boost::get(boost::vertex_color, graph.graph);
+             auto degree_map = boost::make_degree_map(graph.graph);
+             auto priority_map = boost::get(boost::vertex_priority, graph.graph);
 
-        std::vector<Vertex> inv_perm(boost::num_vertices(graph.graph));
+             std::vector<Vertex> inv_perm(boost::num_vertices(graph.graph));
 
-        CHECK_FOR_INTERRUPTS();
+             CHECK_FOR_INTERRUPTS();
 
              boost::sloan_ordering(graph.graph, inv_perm.rbegin(), color_map, degree_map, priority_map, i_map);
 
-         for (typename std::vector<Vertex>::const_iterator i = inv_perm.begin(); i != inv_perm.end(); ++i) {
-                auto seq = graph[*i].id;
-                results.push_back(static_cast<int64_t>(graph[*i].id));
-                seq++;}
+             for (typename std::vector<Vertex>::const_iterator i = inv_perm.begin(); i != inv_perm.end(); ++i) {
+                    auto seq = graph[*i].id;
+                    results.push_back(static_cast<int64_t>(graph[*i].id));
+                    seq++;}
 
-         return results;
-     }
+             return results;
+}
 
 }  // namespace pgrouting
 

--- a/include/ordering/sloanOrdering.hpp
+++ b/include/ordering/sloanOrdering.hpp
@@ -35,7 +35,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <vector>
 #include <map>
 #include <cstdint>
-#include <iterator>
 
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -49,32 +48,51 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/messages.hpp"
 
 namespace pgrouting {
+namespace functions {
 
 template <class G>
-std::vector<int64_t>
-sloanOrdering(G &graph) {
-             typedef typename boost::graph_traits<typename G::graph_t>::vertex_descriptor Vertex;
-             std::vector<int64_t>results;
+class SloanOrdering : public Pgr_messages {
+ public:
+         typedef typename G::V V;
+	 typedef typename G::E E;
+	 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> Graph;
+	 typedef boost::graph_traits<Graph>::vertices_size_type size_type;
+	 typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
 
-             auto i_map = boost::get(boost::vertex_index, graph.graph);
-             auto color_map = boost::get(boost::vertex_color, graph.graph);
-             auto degree_map = boost::make_degree_map(graph.graph);
-             auto priority_map = boost::get(boost::vertex_priority, graph.graph);
+	   std::vector<int64_t>
+           sloanOrdering(G &graph) {
+	   std::vector<int64_t>results;
 
-             std::vector<Vertex> inv_perm(boost::num_vertices(graph.graph));
+	   auto i_map = boost::get(boost::vertex_index, graph.graph);
+	   std::vector<Vertex> inv_perm(boost::num_vertices(graph.graph));
+	   std::vector <boost::default_color_type> colors(boost::num_vertices(graph.graph));
+	   auto color_map = boost::make_iterator_property_map(&colors[0], i_map, colors[0]);
+	   auto out_deg = boost::make_out_degree_map(graph.graph);
+	   std::vector<int> priorities(boost::num_vertices(graph.graph));
+	   auto priority_map = boost::make_iterator_property_map(&priorities[0], i_map, priorities[0]);    
+	   
+	    CHECK_FOR_INTERRUPTS();
+	    
+	    try {
+                boost::sloan_ordering(graph.graph, inv_perm.begin(), color_map, out_deg, priority_map);
+	    } catch (boost::exception const& ex) {
+		(void)ex;
+		throw;
+	    } catch (std::exception &e) {
+		(void)e;
+		throw;
+	    } catch (...) {
+		throw;
+	    }
 
-             CHECK_FOR_INTERRUPTS();
+	    results = get_results(inv_perm, graph);
 
-             boost::sloan_ordering(graph.graph, inv_perm.rbegin(), color_map, degree_map, priority_map, i_map);
+	    return results;
+        }
 
-             for (typename std::vector<Vertex>::const_iterator i = inv_perm.begin(); i != inv_perm.end(); ++i) {
-                    auto seq = graph[*i].id;
-                    results.push_back(static_cast<int64_t>(graph[*i].id));
-                    seq++;}
 
-             return results;
-}
-
+};
+}  // namespace functions
 }  // namespace pgrouting
 
 #endif  // INCLUDE_ORDERING_SLOANORDERING_HPP_

--- a/include/ordering/sloanOrdering.hpp
+++ b/include/ordering/sloanOrdering.hpp
@@ -69,7 +69,7 @@ class SloanOrdering : public Pgr_messages {
            auto color_map = boost::make_iterator_property_map(&colors[0], i_map, colors[0]);
            auto out_deg = boost::make_out_degree_map(graph.graph);
            std::vector<int> priorities(boost::num_vertices(graph.graph));
-           auto priority_map = boost::make_iterator_property_map(&priorities[0], i_map, priorities[0]);    
+           auto priority_map = boost::make_iterator_property_map(&priorities[0], i_map, priorities[0]);
 
             CHECK_FOR_INTERRUPTS();
 

--- a/include/ordering/sloanOrdering.hpp
+++ b/include/ordering/sloanOrdering.hpp
@@ -54,13 +54,15 @@ template <class G>
 std::vector<int64_t>
         sloanOrdering(G &graph) {
              typedef boost::adjacency_list<
-boost::vecS,
-boost::vecS,
-boost::undirectedS,
-boost::property<boost::vertex_color_t, boost::default_color_type,
-boost::property<boost::vertex_degree_t, int,
-boost::property<boost::vertex_priority_t, int>>>> GraphType;
-                typedef typename boost::graph_traits<typename G::graph_t>::vertex_descriptor Vertex;
+                     boost::vecS,boost::vecS,
+                     boost::undirectedS,
+                     boost::property<boost::vertex_color_t,
+                     boost::default_color_type,
+                     boost::property<boost::vertex_degree_t,
+                     int,
+                     boost::property<boost::vertex_priority_t,
+                     int>>>> GraphType;
+             typedef typename boost::graph_traits<typename G::graph_t>::vertex_descriptor Vertex;
                 std::vector<int64_t>results;
 
         auto i_map = boost::get(boost::vertex_index, graph.graph);

--- a/include/ordering/sloanOrdering.hpp
+++ b/include/ordering/sloanOrdering.hpp
@@ -90,6 +90,19 @@ class SloanOrdering : public Pgr_messages {
 	    return results;
         }
 
+ private:
+        std::vector <int64_t> get_results(
+                std::vector <size_type> & inv_perm,
+		const G &graph) {
+		std::vector <int64_t> results;
+           for (std::vector<Vertex>::const_iterator i = inv_perm.begin();
+		i != inv_perm.end(); ++i) {
+		log << inv_perm[*i] << " ";
+		results.push_back(static_cast<int64_t>(graph.graph[*i].id));
+	   }
+
+	   return results;
+}
 
 };
 }  // namespace functions

--- a/include/ordering/sloanOrdering.hpp
+++ b/include/ordering/sloanOrdering.hpp
@@ -54,56 +54,55 @@ template <class G>
 class SloanOrdering : public Pgr_messages {
  public:
          typedef typename G::V V;
-	 typedef typename G::E E;
-	 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> Graph;
-	 typedef boost::graph_traits<Graph>::vertices_size_type size_type;
-	 typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
+         typedef typename G::E E;
+         typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> Graph;
+         typedef boost::graph_traits<Graph>::vertices_size_type size_type;
+         typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
 
-	   std::vector<int64_t>
+           std::vector<int64_t>
            sloanOrdering(G &graph) {
-	   std::vector<int64_t>results;
+           std::vector<int64_t>results;
 
-	   auto i_map = boost::get(boost::vertex_index, graph.graph);
-	   std::vector<Vertex> inv_perm(boost::num_vertices(graph.graph));
-	   std::vector <boost::default_color_type> colors(boost::num_vertices(graph.graph));
-	   auto color_map = boost::make_iterator_property_map(&colors[0], i_map, colors[0]);
-	   auto out_deg = boost::make_out_degree_map(graph.graph);
-	   std::vector<int> priorities(boost::num_vertices(graph.graph));
-	   auto priority_map = boost::make_iterator_property_map(&priorities[0], i_map, priorities[0]);    
-	   
-	    CHECK_FOR_INTERRUPTS();
-	    
-	    try {
+           auto i_map = boost::get(boost::vertex_index, graph.graph);
+           std::vector<Vertex> inv_perm(boost::num_vertices(graph.graph));
+           std::vector <boost::default_color_type> colors(boost::num_vertices(graph.graph));
+           auto color_map = boost::make_iterator_property_map(&colors[0], i_map, colors[0]);
+           auto out_deg = boost::make_out_degree_map(graph.graph);
+           std::vector<int> priorities(boost::num_vertices(graph.graph));
+           auto priority_map = boost::make_iterator_property_map(&priorities[0], i_map, priorities[0]);    
+
+            CHECK_FOR_INTERRUPTS();
+
+            try {
                 boost::sloan_ordering(graph.graph, inv_perm.begin(), color_map, out_deg, priority_map);
-	    } catch (boost::exception const& ex) {
-		(void)ex;
-		throw;
-	    } catch (std::exception &e) {
-		(void)e;
-		throw;
-	    } catch (...) {
-		throw;
-	    }
+            } catch (boost::exception const& ex) {
+                (void)ex;
+                throw;
+            } catch (std::exception &e) {
+                (void)e;
+                throw;
+            } catch (...) {
+                throw;
+            }
 
-	    results = get_results(inv_perm, graph);
+            results = get_results(inv_perm, graph);
 
-	    return results;
+            return results;
         }
 
  private:
         std::vector <int64_t> get_results(
                 std::vector <size_type> & inv_perm,
-		const G &graph) {
-		std::vector <int64_t> results;
+                const G &graph) {
+                std::vector <int64_t> results;
            for (std::vector<Vertex>::const_iterator i = inv_perm.begin();
-		i != inv_perm.end(); ++i) {
-		log << inv_perm[*i] << " ";
-		results.push_back(static_cast<int64_t>(graph.graph[*i].id));
-	   }
+                i != inv_perm.end(); ++i) {
+                log << inv_perm[*i] << " ";
+                results.push_back(static_cast<int64_t>(graph.graph[*i].id));
+           }
 
-	   return results;
+           return results;
 }
-
 };
 }  // namespace functions
 }  // namespace pgrouting

--- a/src/ordering/ordering_driver.cpp
+++ b/src/ordering/ordering_driver.cpp
@@ -40,7 +40,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "ordering/sloanOrdering.hpp"
 
-
+template <class G>
+std::vector <int64_t>
+sloanOrdering(G &graph) {
+	pgrouting::functions::SloanOrdering <G> fn_sloanOrdering;
+	auto results = fn_sloanOrdering.sloanOrdering(graph);
+	return results;
+}
 
 void
 do_ordering(
@@ -69,8 +75,6 @@ do_ordering(
         pgassert(!(*err_msg));
         pgassert(!(*return_tuples));
         pgassert(*return_count == 0);
-
-        using pgrouting::sloanOrdering;
 
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, true);

--- a/src/ordering/ordering_driver.cpp
+++ b/src/ordering/ordering_driver.cpp
@@ -70,11 +70,7 @@ do_ordering(
         pgassert(!(*return_tuples));
         pgassert(*return_count == 0);
 
-#if 0
-        using pgrouting::sloan;
-#endif
-
-#if 0
+        using pgrouting::sloanOrdering;
 
         hint = edges_sql;
         auto edges = pgrouting::pgget::get_edges(std::string(edges_sql), true, true);
@@ -86,13 +82,12 @@ do_ordering(
         log << "Processing Undirected graph\n";
 
         std::vector<int64_t> results;
+
         pgrouting::UndirectedGraph undigraph;
         undigraph.insert_edges(edges);
 
-        std::vector<II_t_rt> results;
-
         if (which == 0) {
-                results = sloan(undigraph);
+                results = sloanOrdering(undigraph);
         }
 
 
@@ -108,7 +103,7 @@ do_ordering(
 
         (*return_tuples) = pgr_alloc(count, (*return_tuples));
 
-        for (size_t i = 0; i < count; ++1) {
+        for (size_t i = 0; i < count; ++i) {
               (*return_tuples)[i] = results[i];
         }
 
@@ -117,7 +112,6 @@ do_ordering(
         pgassert(*err_msg == NULL);
         *log_msg = to_pg_msg(log);
         *notice_msg = to_pg_msg(notice);
-#endif
     } catch (AssertFailedException &except) {
         (*return_tuples) = pgr_free(*return_tuples);
         (*return_count) = 0;

--- a/src/ordering/ordering_driver.cpp
+++ b/src/ordering/ordering_driver.cpp
@@ -40,12 +40,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "ordering/sloanOrdering.hpp"
 
+namespace {
 template <class G>
 std::vector <int64_t>
 sloanOrdering(G &graph) {
-	pgrouting::functions::SloanOrdering <G> fn_sloanOrdering;
-	auto results = fn_sloanOrdering.sloanOrdering(graph);
-	return results;
+        pgrouting::functions::SloanOrdering <G> fn_sloanOrdering;
+        auto results = fn_sloanOrdering.sloanOrdering(graph);
+        return results;
+}
 }
 
 void

--- a/src/ordering/sloanOrdering.c
+++ b/src/ordering/sloanOrdering.c
@@ -58,12 +58,6 @@ _pgr_sloanordering(PG_FUNCTION_ARGS) {
                 &result_tuples,
                 &result_count);
 
-        if (result_count == 0) {
-                result_tuples = (int64_t*)palloc(sizeof(int64_t));
-                result_tuples[0] = 1;
-                result_count = 1;
-        }
-
         funcctx->max_calls = result_count;
         funcctx->user_fctx = result_tuples;
         if (get_call_result_type(fcinfo, NULL, &tuple_desc)


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Make necessary changes in the sloanOrdering.hpp file to call the correct boost function call.
- Add sloan ordering version without weighted graph support.
- Fix existing errors in ordering_driver.cpp file and make the previously disabled code reach a compilable stage.
- Fix necessary code alignment and style issues.
- Call the get_results function to generate results table from function call.
- Remove unrequired code block from sloanOrdering.c file and modified the logic for calling boost function.
- Add example boost query to sloanOrdering.pg file in docqueries/ordering.

@pgRouting/admins
