### PR TITLE
Enable cppcoreguidelines-avoid-c-arrays in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,9 +6,10 @@ Checks: >
     cppcoreguidelines-avoid-capturing-lambda-coroutines,
     cppcoreguidelines-avoid-goto,
     cppcoreguidelines-avoid-non-const-global-variables,
-    cppcoreguidelines-avoid-reference-coroutine-parameters
+    cppcoreguidelines-avoid-reference-coroutine-parameters,
+    cppcoreguidelines-avoid-c-arrays,
 
-WarningsAsErrors: ''
-HeaderFilterRegex: './include'
-FormatStyle:     none
+WarningsAsErrors: ""
+HeaderFilterRegex: "./include"
+FormatStyle: none
 InheritParentConfig: true


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Enable the clang-tidy rule `cppcoreguidelines-avoid-c-arrays` in the `.clang-tidy` configuration.
- This rule helps detect usage of C-style arrays and encourages safer alternatives like `std::array` or `std::vector`.
- Improves adherence of the codebase to C++ Core Guidelines.

@pgRouting/admins
