### PR TITLE
week 9: coreNumbers

### DIFF
--- a/doc/metrics/pgr_coreNumbers.rst
+++ b/doc/metrics/pgr_coreNumbers.rst
@@ -58,6 +58,13 @@ one core number, all vertices in the graph are returned, and the number of rows
 is :math:`|V|`. Results are ordered by ``node`` ascending. When the edge SQL
 returns no rows, the function emits a notice and returns no rows.
 
+**Parallel edges** between the same pair of vertices are collapsed into a single
+edge before the peeling starts, so edge multiplicity does not inflate core
+numbers: three parallel edges between two vertices give both vertices core
+:math:`1`, the same as a single edge. This matters when importing road networks
+that contain duplicate geometry. A **self loop** is not removed and still
+contributes to the degree of its own vertex.
+
 |Boost| Boost Graph Inside
 
 .. rubric:: References

--- a/pgtap/metrics/coreNumbers/edge_cases.pg
+++ b/pgtap/metrics/coreNumbers/edge_cases.pg
@@ -6,7 +6,7 @@
 BEGIN;
 
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE WHEN NOT min_version('4.1.0') THEN plan(1) ELSE plan(25) END;
+SELECT CASE WHEN NOT min_version('4.1.0') THEN plan(1) ELSE plan(26) END;
 
 CREATE OR REPLACE FUNCTION edge_cases()
 RETURNS SETOF TEXT AS
@@ -296,7 +296,8 @@ SELECT results_eq('ordering_q', 'ordering_r',
   'Results are ordered by node ascending without an explicit ORDER BY');
 
 
-/* parallel edges count towards the degree */
+/* parallel edges are collapsed to a single edge, keeping the lowest cost,
+   so they do not inflate the degree */
 
 PREPARE parallel_q AS
   SELECT node, core FROM pgr_coreNumbers(
@@ -307,13 +308,27 @@ PREPARE parallel_q AS
 
 PREPARE parallel_r AS
   SELECT * FROM (VALUES
-    (1::BIGINT, 2::BIGINT),
-    (2, 2))
+    (1::BIGINT, 1::BIGINT),
+    (2, 1))
   AS t(node, core);
 
 RETURN QUERY
 SELECT results_eq('parallel_q', 'parallel_r',
-  'Two parallel edges give both vertices core 2');
+  'Two parallel edges are collapsed: both vertices are core 1');
+
+
+/* three parallel edges also collapse to a single edge */
+
+PREPARE parallel3_q AS
+  SELECT node, core FROM pgr_coreNumbers(
+    'SELECT * FROM (VALUES
+      (1,1,2,1.0,1.0),(2,1,2,1.0,1.0),(3,1,2,1.0,1.0))
+     AS t(id, source, target, cost, reverse_cost)'
+  ) ORDER BY node;
+
+RETURN QUERY
+SELECT results_eq('parallel3_q', 'parallel_r',
+  'Three parallel edges are collapsed: both vertices are core 1');
 
 
 /* a self loop counts towards the degree of its vertex */

--- a/src/metrics/coreNumbers_driver.cpp
+++ b/src/metrics/coreNumbers_driver.cpp
@@ -73,7 +73,7 @@ do_coreNumbers(
         hint = "";
 
         pgrouting::UndirectedGraph undigraph;
-        undigraph.insert_edges(edges);
+        undigraph.insert_min_edges_no_parallel(edges);
 
         auto results = coreNumbers(undigraph);
 


### PR DESCRIPTION
### Targets for this PR
- [ ] Add pgr_coreNumbers strings to `locale/pot/pgrouting_doc_strings.pot`
- [x] Act on the Discourse answer about multigraph semantics
      (parallel edges / self-loops contributing to degree)
  - [ ] If Option A: document the behaviour under Description in
        \`pgr_coreNumbers.rst\` and keep the characterisation tests
  - [x] If Option B: collapse parallel edges before peeling, update the
        affected pgTAP tests and docqueries

Parallel edges are now collapsed via \`insert_min_edges_no_parallel\` per the Discourse discussion. Self-loop handling and the locale/pot regeneration are follow-up work in the week 10 PR.
