### PR TITLE
week 10: planarFaces

### DIFF
--- a/doc/planar/pgr_planarFaces.rst
+++ b/doc/planar/pgr_planarFaces.rst
@@ -52,6 +52,13 @@ succeeds. Face identifiers come from the traversal; one is the exterior face.
 An empty edge SQL emits a notice and returns no rows. Running time is
 :math:`O(|V| + |E|)`.
 
+The number of faces obeys **Euler's formula**. On a connected planar graph
+:math:`|V| - |E| + |F| = 2`. The traversal walks the outer face of every
+connected component separately, so on a graph with :math:`C` components the
+relation generalises to :math:`|V| - |E| + |F| = 2C`. On the
+:doc:`sampledata` network, which has :math:`3` components,
+:math:`17 - 18 + 7 = 6 = 2 \times 3`.
+
 |Boost| Boost Graph Inside
 
 .. rubric:: References

--- a/pgtap/planar/planarFaces/edge_cases.pg
+++ b/pgtap/planar/planarFaces/edge_cases.pg
@@ -6,7 +6,7 @@
 BEGIN;
 
 UPDATE edges SET cost = sign(cost), reverse_cost = sign(reverse_cost);
-SELECT CASE WHEN min_version('4.1.0') THEN plan (8) ELSE plan(1) END;
+SELECT CASE WHEN min_version('4.1.0') THEN plan (10) ELSE plan(1) END;
 
 CREATE OR REPLACE FUNCTION edge_cases()
 RETURNS SETOF TEXT AS
@@ -51,7 +51,8 @@ SELECT set_eq('singleEdgeTest',
     $$,
     '3: Single edge has 2 face-edge incidences');
 
--- triangle: 3 edges, 2 faces, 6 rows
+-- open path 11 - 7 - 8 - 12 (edges 8, 10, 12): a tree has no interior face,
+-- so all 3 edges border the single exterior face, still giving 2|E| = 6 rows
 PREPARE q4 AS
 SELECT id, source, target, cost, reverse_cost
 FROM edges
@@ -63,7 +64,7 @@ SELECT count(*) FROM pgr_planarFaces('q4');
 RETURN QUERY
 SELECT set_eq('triangleTest',
     $$VALUES (6::BIGINT) $$,
-    '4: Triangle has 6 rows (2 faces x 3 edges)');
+    '4: Open path of 3 edges has 6 rows, all on the exterior face');
 
 -- total rows = 2 * number of edges
 PREPARE q5 AS
@@ -102,6 +103,44 @@ RETURN QUERY
 SELECT set_eq('subgraphTest',
     $$VALUES (18::BIGINT) $$,
     '7: Subgraph id < 10 has 18 rows (2 x 9 edges)');
+
+-- Euler's formula on a connected planar graph: V - E + F = 2
+-- edges id < 10 form a single connected component with 9 vertices and 9 edges,
+-- so the traversal must find exactly 2 faces
+
+PREPARE eulerConnected AS
+SELECT (
+    (SELECT count(*) FROM (
+        SELECT source AS n FROM edges WHERE id < 10
+        UNION SELECT target FROM edges WHERE id < 10) v)      -- V
+  - (SELECT count(*) FROM edges WHERE id < 10)                -- E
+  + (SELECT count(DISTINCT face_id) FROM pgr_planarFaces(
+        'SELECT id, source, target, cost, reverse_cost
+        FROM edges WHERE id < 10'))                           -- F
+  )::BIGINT;
+
+RETURN QUERY
+SELECT set_eq('eulerConnected',
+    $$VALUES (2::BIGINT) $$,
+    '9: Euler formula on a connected subgraph: V - E + F = 2');
+
+-- Generalised Euler formula on a disconnected graph: V - E + F = 2 * C
+-- the traversal walks the outer face of every component separately, so each
+-- of the 3 components of the full sample network contributes 2
+
+PREPARE eulerDisconnected AS
+SELECT (
+    (SELECT count(*) FROM (
+        SELECT source AS n FROM edges UNION SELECT target FROM edges) v)
+  - (SELECT count(*) FROM edges)
+  + (SELECT count(DISTINCT face_id) FROM pgr_planarFaces(
+        'SELECT id, source, target, cost, reverse_cost FROM edges'))
+  )::BIGINT;
+
+RETURN QUERY
+SELECT set_eq('eulerDisconnected',
+    $$VALUES (6::BIGINT) $$,
+    '10: Euler formula on the disconnected sample network: V - E + F = 2 * 3 components');
 
 -- non-planar graph (K5 minor) raises error
 INSERT INTO edges (source, target, cost, reverse_cost) VALUES


### PR DESCRIPTION
### Targets for this PR
- [x] Add pgTAP tests for Euler's formula
- [x] Fix wrong test description in edge_cases.pg

While adding the Euler tests I noticed test 4 says "Triangle has 6 rows (2 faces x 3 edges)" but edges 8, 10, 12 are 7-11, 7-8, 8-12, which is an open path and not a triangle. It has 1 face not 2, so I corrected the description. The row count of 6 was still right.

For the Euler tests I checked a few subgraphs first:

- edges 8,10,12 -> V=4 E=3 F=1 -> V-E+F = 2
- id < 10 -> V=9 E=9 F=2 -> V-E+F = 2
- id < 5 -> V=5 E=4 F=1 -> V-E+F = 2
- full graph -> V=17 E=18 F=7 -> V-E+F = 6

The full graph gives 6 because it has 3 components (checked with pgr_connectedComponents) and the traversal walks the outer face of each component separately, so it comes out as 2C instead of 2. Added a test for both cases and mentioned it in the Description section of the rst.

pgtap is 76 now, was 74. docqueries still pass.

@pgRouting/admins