### PR TITLE
Boost version PoC: planarFaces

### DIFF
--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -70,7 +70,11 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          boost_minor: [56, 68, 75, 76, 77, 78, 79, 80, 83, 84, 86]
+          # boost version proof of concept for pgr_planarFaces
+          # 55: previous  -> expected to fail (below BOOST_MINIMUM_VERSION 1.56.0)
+          # 56: critical  -> expected to pass
+          # 57: next      -> expected to pass
+          boost_minor: [55, 56, 57]
 
     steps:
       - uses: actions/checkout@v6
@@ -107,8 +111,8 @@ jobs:
             postgresql-${PGVER}-postgis-${PGIS}-scripts \
             postgresql-server-dev-${PGVER}
 
-          wget https://sourceforge.net/projects/boost/files/boost/1.${{ matrix.boost_minor }}.0/boost_1_${{ matrix.boost_minor }}_0.tar.bz2
-          #wget https://dl.bintray.com/boostorg/release/1.${{ matrix.boost_minor }}.0/source/boost_1_${{ matrix.boost_minor }}_0.tar.bz2
+          # official boost archive, releases are never retired
+          wget https://archives.boost.io/release/1.${{ matrix.boost_minor }}.0/source/boost_1_${{ matrix.boost_minor }}_0.tar.bz2
           sudo tar --bzip2 -xf  boost_1_${{ matrix.boost_minor }}_0.tar.bz2
           sudo mv boost_1_${{ matrix.boost_minor }}_0/boost /usr/include/
 

--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -70,10 +70,6 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          # boost version proof of concept for pgr_planarFaces
-          # 55: previous  -> expected to fail (below BOOST_MINIMUM_VERSION 1.56.0)
-          # 56: critical  -> expected to pass
-          # 57: next      -> expected to pass
           boost_minor: [55, 56, 57]
 
     steps:


### PR DESCRIPTION
Rebuilt this PoC on top of sakir-2026-face-extraction. The earlier version was
branched from main and contained none of my algorithm code, so the all-pass
result said nothing about planarFaces. Also corrected the earlier body, which
claimed 1.79 failed when CI showed it passing.

- 1.55 expected to fail (below BOOST_MINIMUM_VERSION 1.56.0 in CMakeLists.txt)
- 1.56 expected to pass (critical version)
- 1.57 expected to pass

pgr_planarFaces uses graph_traits, property_map, boyer_myrvold_planar_test and
planar_face_traversal, all present in boost since 1.40, so the algorithm does
not raise pgRouting's declared 1.56 minimum.

Download switched from sourceforge to https://archives.boost.io.

Result: