### PR TITLE
boost_version.yml: PoC for coreNumbers

### DIFF
--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -70,7 +70,11 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          boost_minor: [56, 68, 75, 76, 77, 78, 79, 80, 83, 84, 86]
+          # boost version proof of concept for pgr_coreNumbers
+          # 55: previous  -> expected to fail (below BOOST_MINIMUM_VERSION 1.56.0)
+          # 56: critical  -> expected to pass
+          # 57: next      -> expected to pass
+          boost_minor: [55, 56, 57]
 
     steps:
       - uses: actions/checkout@v6
@@ -107,8 +111,8 @@ jobs:
             postgresql-${PGVER}-postgis-${PGIS}-scripts \
             postgresql-server-dev-${PGVER}
 
-          wget https://sourceforge.net/projects/boost/files/boost/1.${{ matrix.boost_minor }}.0/boost_1_${{ matrix.boost_minor }}_0.tar.bz2
-          #wget https://dl.bintray.com/boostorg/release/1.${{ matrix.boost_minor }}.0/source/boost_1_${{ matrix.boost_minor }}_0.tar.bz2
+          # official boost archive, releases are never retired
+          wget https://archives.boost.io/release/1.${{ matrix.boost_minor }}.0/source/boost_1_${{ matrix.boost_minor }}_0.tar.bz2
           sudo tar --bzip2 -xf  boost_1_${{ matrix.boost_minor }}_0.tar.bz2
           sudo mv boost_1_${{ matrix.boost_minor }}_0/boost /usr/include/
 

--- a/.github/workflows/boost_version.yml
+++ b/.github/workflows/boost_version.yml
@@ -70,10 +70,6 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          # boost version proof of concept for pgr_coreNumbers
-          # 55: previous  -> expected to fail (below BOOST_MINIMUM_VERSION 1.56.0)
-          # 56: critical  -> expected to pass
-          # 57: next      -> expected to pass
           boost_minor: [55, 56, 57]
 
     steps:


### PR DESCRIPTION
## Boost version proof of concept for pgr_coreNumbers

Branched from \`sakir-2026-core-decomposition\` so the matrix actually compiles coreNumbers against each boost version.

- **1.55** -> expected to **fail** (below \`BOOST_MINIMUM_VERSION 1.56.0\` in CMakeLists.txt)
- **1.56** -> expected to **pass** (critical version)
- **1.57** -> expected to **pass**

### Why 1.56

\`pgr_coreNumbers\` includes no boost headers at all. Batagelj-Zaversnik is hand written and only uses pgRouting's own \`UndirectedGraph\`, so the algorithm itself imposes no boost requirement. The floor comes from the project minimum,
not from my code.

### Also changed

Download switched from sourceforge to https://archives.boost.io, the official archive. Sourceforge is unreliable, it failed 20 retries with \"No data received\" on another boost PoC run so the tarball never downloaded and the job failed for reasons unrelated to boost.

### Result